### PR TITLE
Added jupyterhub installer

### DIFF
--- a/app-data/ipython/ir_kernel.r
+++ b/app-data/ipython/ir_kernel.r
@@ -1,0 +1,8 @@
+install.packages('devtools', repos='http://cran.us.r-project.org')
+install.packages('RCurl', repos='http://cran.us.r-project.org')
+library(devtools)
+install_github('IRkernel/repr')
+install_github('IRkernel/IRdisplay')
+install_github('IRkernel/IRkernel')
+IRkernel::installspec()
+q()

--- a/app-data/ipython/jupyter.sh
+++ b/app-data/ipython/jupyter.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -l
+ 
+PREFIX=/usr/
+ 
+export LD_LIBRARY_PATH=/usr/lib/grass70/lib:$PREFIX/lib/R/lib/:$LD_LIBRARY_PATH
+export PYTHONPATH=/usr/lib/grass70/etc/python:$PYTHONPATH
+export GISBASE=/usr/lib/grass70
+export PATH=$GISBASE/bin:$GISBASE/scripts:$PATH
+ 
+export GIS_LOCK=$$
+ 
+mkdir -p /home/epilib/Envs/grass7data
+mkdir -p /home/epilib/Envs/.grass7
+ 
+export GISRC=/home/user/.grass7/rc
+export GISDBASE=/home/user/grassdata
+ 
+export GRASS_TRANSPARENT=TRUE
+export GRASS_TRUECOLOR=TRUE
+export GRASS_PNG_COMPRESSION=9
+export GRASS_PNG_AUTO_WRITE=TRUE
+ 
+GISBASE="/usr/lib/grass70/"
+PATH="$GISBASE/bin:$GISBASE/scripts:$PATH"
+GIS_LOCK="$$"
+GISRC="/home/$USER/.grass7/rc"
+ 
+export LD_LIBRARY_PATH PYTHONPATH GISBASE PATH GIS_LOCK GISRC
+ 
+# note: $GISDBASE is generally a g.gisenv variable stored in .grassrc6, not a shell variable anymore
+GRASS_RENDER_IMMEDIATE=cairo
+GRASS_RENDER_WIDTH=640
+GRASS_RENDER_HEIGHT=480
+GRASS_RENDER_FILE_READ=TRUE
+GRASS_RENDER_TRANSPARENT=TRUE
+GRASS_RENDER_TRUECOLOR=TRUE
+GRASS_RENDER_PNG_COMPRESSION=9
+GRASS_RENDER_PNG_AUTO_WRITE=TRUE
+GRASS_RENDER_READ_FILE=TRUE
+export GRASS_RENDER_FILE_READ GRASS_RENDER_IMMEDIATE GRASS_RENDER_WIDTH GRASS_RENDER_HEIGHT GRASS_RENDER_TRANSPARENT GRASS_RENDER_TRUECOLOR GRASS_RENDER_PNG_COMPRESSION GRASS_RENDER_PNG_AUTO_WRITE GRASS_RENDER_READ_FILE
+ 
+ 
+jupyterhub --config=/usr/local/share/jupyter/jupyterhub_config.py --debug

--- a/app-data/ipython/jupyterhub-start.desktop
+++ b/app-data/ipython/jupyterhub-start.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Encoding=UTF-8
+Name=Start Jupyterhub
+Comment=Jupyterhub
+Categories=Application;Education;Geography;
+Exec=/usr/local/bin/Jupyter.sh
+Icon=ipython
+Terminal=true
+StartupNotify=false

--- a/app-data/ipython/jupyterhub.desktop
+++ b/app-data/ipython/jupyterhub.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Encoding=UTF-8
+Name=Jupyterhub
+Comment=Jupyterhub
+Categories=Application;Education;Geography;
+Exec=firefox http://localhost:8888
+Icon=ipython
+Terminal=false
+StartupNotify=false
+MimeType=application/x-ipynb+json;

--- a/app-data/ipython/jupyterhub_config.py
+++ b/app-data/ipython/jupyterhub_config.py
@@ -1,0 +1,32 @@
+# Configuration file for jupyterhub.
+ 
+from jupyterhub.spawner import LocalProcessSpawner
+ 
+class MySpawner(LocalProcessSpawner):
+    def user_env(self, env):
+        env = super().user_env(env)
+        env['GISRC'] = '/home/%s/.grass7/rc' % self.user.name
+        return env
+ 
+c = get_config()
+ 
+c.JupyterHub.spawner_class = MySpawner
+ 
+c.Spawner.notebook_dir = '~/jupyter'
+ 
+c.JupyterHub.port = 8888 
+ 
+c.JupyterHub.proxy_api_port = 9985
+c.JupyterHub.hub_port = 9995
+#c.JupyterHub.proxy_auth_token = ''
+ 
+c.JupyterHub.admin_users = {'user'}
+ 
+c.JupyterHub.config_file = '/usr/local/share/jupyter/jupyterhub_config.py'
+ 
+#c.JupyterHub.data_files_path = '/usr/local/share/jupyter'
+ 
+c.Spawner.env_keep = ['PATH', 'PYTHONPATH', 'LD_LIBRARY_PATH', 'GISBASE', 'GIS_LOCK', 'GISRC', 'GISDBASE','GRASS_RENDER_IMMEDIATE','GRASS_RENDER_FILE_COMPRESSION','GRASS_RENDER_WIDTH','GRASS_RENDER_HEIGHT','GRASS_RENDER_TRANSPARENT','GRASS_RENDER_FILE_READ','GRASS_RENDER_TRUECOLOR','GRASS_RENDER_PNG_AUTO_WRITE', 'LANG', 'LC_ALL']
+ 
+c.JupyterHub.admin_users = {'user'}
+c.JupyterHub.hub_ip = 'localhost'

--- a/bin/install_ipython.sh
+++ b/bin/install_ipython.sh
@@ -92,6 +92,54 @@ if [ ! -d "/etc/skel/.ipython/nbextensions" ] ; then
    ln -s /var/www/html/reveal.js/ /etc/skel/.ipython/nbextensions/ 
 fi
 
+### INSTALL JUPYTERHUB ###
+
+#apt-get update
+#apt-get upgrade
+# apt-get install gnome-terminal # few kb to make terminal experience much more enjoyable (copy/paste drug'n'drop)
+
+# jupyterhub depends on python3
+apt-get install python3-pip
+npm install -g configurable-http-proxy
+# be sure build toold and libs are here
+apt-get install build-essential python-dev
+apt-get install python3.4-dev
+apt-get install libzmq3-dev
+apt-get install libcurl4-openssl-dev
+# main dependences for python 3
+pip3 install zmq
+pip3 install jsonschema
+pip3 install terminado
+# install jupyterhub from git repository
+git clone https://github.com/jupyter/jupyterhub.git
+cd jupyterhub
+pip install -r requirements.txt
+pip3 install -r requirements.txt
+pip3 install .
+cd ..
+rm -rf jupyterhub
+# add python 2 and 3 kernels
+python -m IPython kernelspec install-self
+python3 -m IPython kernelspec install-self
+# add bash kernel
+pip3 install bash_kernel
+# install R kernel
+Rscript "$BUILD_DIR"/../app-data/ipython/ir_kernel.r
+# add octave kernel
+apt-get install octave # 53.5 MB of additional disk space
+pip3 install octave_kernel
+
+
+cp "$BUILD_DIR"/../app-data/ipython/jupyter*.sh \
+   /usr/local/bin/
+chmod a+x /usr/local/bin/jupyter*.sh
+
+cp "$BUILD_DIR"/../app-data/ipython/ipython-notebook*.desktop \
+   "$USER_DESKTOP"/
+chown "$USER_NAME:$USER_NAME" "$USER_DESKTOP"/ipython-notebook*.desktop
+
+cp "$BUILD_DIR"/../app-data/ipython/jupyterhub_config.py \
+  /usr/local/share/jupyter/
 
 ####
 ./diskspace_probe.sh "`basename $0`" end


### PR DESCRIPTION
This PR add the [jupyterhub](https://github.com/jupyter/jupyterhub#jupyterhub-a-multi-user-server-for-jupyter-notebooks) into osgeolive. 
It includes kernels for the following languages: 
* python2
* python3
* R
* bash
* octave

the server can run on any port, the config for now uses (changes needed before merge if any conflict with other apps running on same port): 
- 8888, 9985, 9995

