### PR TITLE
Use debian packages of the docs

### DIFF
--- a/bin/inchroot.sh
+++ b/bin/inchroot.sh
@@ -183,7 +183,7 @@ export USER_NAME
 ./install_cesium.sh
 
 ./load_gisdata.sh
-# ./install_docs.sh
+./install_docs.sh
 ./install_edutools.sh
 
 ./install_desktop.sh

--- a/bin/install_docs.sh
+++ b/bin/install_docs.sh
@@ -33,7 +33,7 @@ DATA_FOLDER="/usr/local/share/data"
 #Install from daily repository
 add-apt-repository  --yes ppa:johanvdw/osgeolive-doc-daily
 apt-get update
-apt-get install osgeolive-docs javascript-common
+apt-get install --assume-yes osgeolive-docs javascript-common
 
 ln -s /usr/share/doc/osgeolive-docs $DEST/osgeolive
 

--- a/bin/install_docs.sh
+++ b/bin/install_docs.sh
@@ -30,115 +30,11 @@ USER_HOME="/home/$USER_NAME"
 DEST="/var/www/html"
 DATA_FOLDER="/usr/local/share/data"
 
+#Install from daily repository
+add-apt-repository  ppa:johanvdw/osgeolive-doc-daily
+apt-get install osgeolive-docs javascript-common
 
-apt-get --assume-yes install python-sphinx
-
-# Use sphynx to build the OSGeo-Live documentation
-cd "$BUILD_DIR"/../doc
-make clean
-make html
-
-# Create target directory if it doesn't exist
-mkdir -p "$DEST"
-
-# Remove then replace target documentation, leaving other files
-cd "$BUILD_DIR"/../doc/_build/html
-for FILE in `ls` ; do
-  rm -fr "$DEST/$FILE"
-done
-mv * "$DEST"
-
-# post-install cleanup build dir
-cd "$BUILD_DIR"/../doc
-make clean
-
-
-#### work around sphinx bug #704: clear out duplicate images
-#  (osgeo trac #952)
-replace_w_symlink()
-{
-# only act if base is a regular file
-if [ -f "$NONUM.$ext" ] ; then
-   # only act if files are identical
-   diff "$NONUM.$ext" "$file" > /dev/null
-   if [ $? -eq 0 ] ; then
-      #echo "[$file] -> [$NONUM.$ext]"
-      rm -f "$file"
-      ln -s "$NONUM.$ext" "$file"
-      # avoid the need for symlinks
-      #HITS=`grep -rl "../../_images/$file.$ext" ../[a-z][a-z]/*`
-      #if [ -n "$HITS" ] ; then
-      #   sed -i -e "s|../../_images/$file.$ext|../../_images/$NONUM.$ext|" $HITS
-      #fi
-   fi
-fi
-}
-
-cd "$DEST/_images/"
-SPHX_VER=`dpkg -l python-sphinx | grep sphinx | awk '{print $3}' | cut -f1 -d'+'`
-if [ "$SPHX_VER" = "1.2.2" ] ; then
-   for ext in png jpg gif ; do
-      for file in *.$ext ; do
-	 if [ -h "$file" ] ; then
-	    # already a symlink
-	    continue
-	 fi
-
-	 NONUM=`echo "$file" | sed -e "s/[0-9]\+\.$ext//"`
-
-	 if [ -h "$NONUM.$ext" ] ; then
-	    # replace anyway?? base is already a symlink
-	    continue
-	 fi
-
-	 if [ "$NONUM" = "$file" ] ; then
-	    continue
-	 fi
-
-	 if [ -f "$NONUM.$ext" ] ; then
-	    replace_w_symlink
-	    continue
-	 fi
-
-	   # try with a number after it
-	 if [ `ls "$NONUM"[0-9]."$ext" 2> /dev/null | wc -l` -gt 0 ] ; then
-	    NONUM=`echo "$file" | sed -e "s/[0-9]\.$ext//"`
-	    if [ -f "$NONUM.$ext" ] ; then
-	       replace_w_symlink
-	       continue
-            fi
-	 fi
-
-	   # or two
-	 if [ `ls "$NONUM"[0-9][0-9]."$ext" 2> /dev/null | wc -l` -gt 0 ] ; then
-	    NONUM=`echo "$file" | sed -e "s/[0-9]\.$ext//"`
-	    if [ -f "$NONUM.$ext" ] ; then
-	       replace_w_symlink
-	       continue
-            fi
-	 fi
-
-	   # or three
-	 if [ `ls "$NONUM"[0-9][0-9][0-9]."$ext" 2> /dev/null | wc -l` -gt 0 ] ; then
-	    NONUM=`echo "$file" | sed -e "s/[0-9]\.$ext//"`
-	    if [ -f "$NONUM.$ext" ] ; then
-	       replace_w_symlink
-	       continue
-            fi
-	 fi
-
-	   # or four
-	 if [ `ls "$NONUM"[0-9][0-9][0-9][0-9]."$ext" 2> /dev/null | wc -l` -gt 0 ] ; then
-	    NONUM=`echo "$file" | sed -e "s/[0-9]\.$ext//"`
-	    if [ -f "$NONUM.$ext" ] ; then
-	       replace_w_symlink
-	       continue
-            fi
-	 fi
-	 # ... still more?
-      done
-   done
-fi
+ln -s /usr/share/doc/osgeolive-docs $DEST
 
 # Create symbolic links to project specific documentation
 cd "$DEST"

--- a/bin/install_docs.sh
+++ b/bin/install_docs.sh
@@ -31,10 +31,11 @@ DEST="/var/www/html"
 DATA_FOLDER="/usr/local/share/data"
 
 #Install from daily repository
-add-apt-repository  ppa:johanvdw/osgeolive-doc-daily
+add-apt-repository  --yes ppa:johanvdw/osgeolive-doc-daily
+apt-get update
 apt-get install osgeolive-docs javascript-common
 
-ln -s /usr/share/doc/osgeolive-docs $DEST
+ln -s /usr/share/doc/osgeolive-docs $DEST/osgeolive
 
 # Create symbolic links to project specific documentation
 cd "$DEST"


### PR DESCRIPTION
Here is a patch to install the debian package of the docs.

I have made a change compared to the current setup (second commit): rather than having the osgeo live docs themselve present at /var/www/html I put them in a subdirectory /var/www/html/osgeolive . I think this is better, because we used to have subdirectories for all the different projects mixed with the different languages of the livedvd. This has the disadvantage that we should check whether all links still work. Feel free to comment if you don't like that.