### PR TITLE
Make localhost/osgeolive point to html dir

### DIFF
--- a/bin/install_docs.sh
+++ b/bin/install_docs.sh
@@ -35,7 +35,7 @@ add-apt-repository  --yes ppa:johanvdw/osgeolive-doc-daily
 apt-get update
 apt-get install --assume-yes osgeolive-docs javascript-common
 
-ln -s /usr/share/doc/osgeolive-docs $DEST/osgeolive
+ln -s /usr/share/doc/osgeolive-docs/html $DEST/osgeolive
 
 # Create symbolic links to project specific documentation
 cd "$DEST"


### PR DESCRIPTION
As proposed in a comment at: https://github.com/OSGeo/OSGeoLive/pull/22 -
Use eg
http://localhost/osgeolive/en/quickstart/52nWPS_quickstart.html
instead of:
http://localhost/osgeolive/html/en/quickstart/52nWPS_quickstart.html