### PR TITLE
Install virtualbox guest additions by default

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -191,7 +191,7 @@ apt-get install --yes gcc build-essential devscripts pbuilder fakeroot \
 # Install virtualbox guest additions
 # If running on virtualbox this will allow us to use full-screen/usb2/...
 # If running outside virtualbox the drivers will not be loaded
-apt-get install virtualbox-guest-dkms virtualbox-guest-x11 virtualbox-guest-utils
+apt-get install --yes virtualbox-guest-dkms virtualbox-guest-x11 virtualbox-guest-utils
 
 # install the python .deb maker
 apt-get install --yes python-stdeb python-all-dev

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -188,6 +188,11 @@ apt-get install --yes apturl
 apt-get install --yes gcc build-essential devscripts pbuilder fakeroot \
   svn-buildpackage lintian debhelper pkg-config dpkg-dev cmake
 
+# Install virtualbox guest additions
+# If running on virtualbox this will allow us to use full-screen/usb2/...
+# If running outside virtualbox the drivers will not be loaded
+apt-get install virtualbox-guest-dkms virtualbox-guest-x11 virtualbox-guest-utils
+
 # install the python .deb maker
 apt-get install --yes python-stdeb python-all-dev
 


### PR DESCRIPTION
When running a workshop, the virtualboximages are very hard to use. I don't see any good reason not to install the virtualbox additions by default. When running natively the drivers will not be loaded.

I just tested this at FOSS4G Europe during the OTB workshop and I found no issues when installing these packages on a lot of different combinations of Virtualbox/different host os'es.