### PR TITLE
replace GRASS dataset with the one maintained by GRASS community

### DIFF
--- a/bin/install_grass.sh
+++ b/bin/install_grass.sh
@@ -117,11 +117,12 @@ fi
 ##############
 # New dataset#
 ##############
-FILE="loc_ncarolina_spm_base0.3.1.zip"
-FOLDER_NAME="loc_ncarolina_spm_base0.3.1"
+#This dataset is maintained by GRASS community
+FILE="nc_basic_spm_grass7.zip"
+FOLDER_NAME="nc_basic_spm_grass7"
 cd "$TMP_DIR"
 wget -c --progress=dot:mega \
-     "http://www4.ncsu.edu/~hmitaso/grasswork/grassbookdat4ed/loc_ncarolina_spm_base0.3.1.zip"
+     "https://grass.osgeo.org/sampledata/north_carolina/nc_basic_spm_grass7.zip"
 unzip "$FILE" -d /usr/local/share/grass/
 cd /usr/local/share/grass/
 chown -R root.users "$FOLDER_NAME"


### PR DESCRIPTION
Trying my my tutorial for FOSS4G 2015 in Seoul I discovered that the GRASS sample data it is not the [official one](https://grass.osgeo.org/download/sample-data/) but another one provide by [Helena Mitasova](http://www4.ncsu.edu/~hmitaso/grasswork/grassbookdat4ed/). I also discovered that this dataset as at least one dataset broken (landuse).

Regards 
Luca