### PR TITLE
add gdal-bin dependency

### DIFF
--- a/bin/install_jupyter.sh
+++ b/bin/install_jupyter.sh
@@ -33,7 +33,8 @@ apt-get install --assume-yes  python-matplotlib \
         python-shapely python-rasterio python-fiona \
         python-geopandas python-descartes \
         python-enum34 python-geojson python-folium \
-        python-pysal fiona rasterio
+        python-pysal fiona rasterio gdal-bin
+
 
 #-- Jupyter ppa
 apt-add-repository --yes ppa:gcpp-kalxas/jupyter


### PR DESCRIPTION
Testing a notebook which use ```gdalinfo```:

 The program 'gdalinfo' is currently not installed. You can install it by typing:
sudo apt-get install gdal-bin