### PR TITLE
Update load_gisdata.sh

### DIFF
--- a/bin/load_gisdata.sh
+++ b/bin/load_gisdata.sh
@@ -273,13 +273,15 @@ touch "$DATA_FOLDER"/north_carolina/shape/epsg-3358.txt
 
 
 cd "$TMP"
+
 #### Updated North Carolina KML
-DATA_URL="http://geofemengineering.it/osgeolive/"
-wget -N --progress=dot:mega "$DATA_URL/ossim_data/kml.tar.gz"
-tar xzf kml.tar.gz
-chown -R root.root kml/
-mv -f kml/* "$DATA_FOLDER"/north_carolina/kml/
-rm -rf kml/
+# this dataset and website are no longer available
+#DATA_URL="http://geofemengineering.it/osgeolive/"
+#wget -N --progress=dot:mega "$DATA_URL/ossim_data/kml.tar.gz"
+#tar xzf kml.tar.gz
+#chown -R root.root kml/
+#mv -f kml/* "$DATA_FOLDER"/north_carolina/kml/
+#rm -rf kml/
 
 
 # create overviews and histograms for OSSIM
@@ -287,27 +289,43 @@ OSSIM_PREFS_FILE=/usr/share/ossim/ossim_preference
 export OSSIM_PREFS_FILE
 
 # replace 32bit Landsat files with 8bit versions
-DATA_DIR="$DATA_FOLDER/north_carolina/rast_geotiff"
+#DATA_DIR="$DATA_FOLDER/north_carolina/rast_geotiff"
 
-for BAND in 10 20 30 40 50 61 62 70 80 ; do
-   BASENAME="lsat7_2002_$BAND.tif"
-   NEWNAME="lsat7_2002_${BAND}_8bit.tif"
+# this dataset are not found in the north_carolina/rast_geotiff directory
 
-   /usr/bin/gdal_translate -ot Byte "$DATA_DIR/$BASENAME" "$DATA_DIR/$NEWNAME"
-   rm "$DATA_DIR/$BASENAME"
-   mv "$DATA_DIR/$NEWNAME" "$DATA_DIR/$BASENAME"
+#for BAND in 10 20 30 40 50 61 62 70 80 ; do
+#   BASENAME="lsat7_2002_$BAND.tif"
+#   NEWNAME="lsat7_2002_${BAND}_8bit.tif"
 
-   ossim-img2rr "$DATA_DIR/$BASENAME"
-   ossim-create-histo "$DATA_DIR/$BASENAME"
-done
+#   /usr/bin/gdal_translate -ot Byte "$DATA_DIR/$BASENAME" "$DATA_DIR/$NEWNAME"
+#   rm "$DATA_DIR/$BASENAME"
+#   mv "$DATA_DIR/$NEWNAME" "$DATA_DIR/$BASENAME"
 
-/usr/local/ossim/bin/ossim-orthoigen --writer general_raster_bip \
+#   ossim-img2rr "$DATA_DIR/$BASENAME"
+#   ossim-create-histo "$DATA_DIR/$BASENAME"
+#done
+
+/usr/bin/ossim-orthoigen --writer general_raster_bip \
    "$DATA_DIR/elevation.tif" \
    /usr/share/ossim/elevation/nc/elevation.ras
 
-/usr/local/ossim/bin/ossim-orthoigen --writer general_raster_bip \
+/usr/bin/ossim-orthoigen --writer general_raster_bip \
    "$DATA_DIR/elev_lid792_1m.tif" \
    /usr/share/ossim/elevation/lidar/elev_lid792_1m.ras
+
+
+# add landsat and srtm dataset
+cd $DATA_FOLDER
+wget -N --progress=dot:mega "http://download.osgeo.org/livedvd/data/ossim/landsat.tar.gz"
+tar xzf landsat.tar.gz
+chgrp users landsat
+chmod g+w landsat
+rm -rf landsat.tar.gz
+
+# make srtm elevation
+/usr/bin/ossim-orthoigen --writer general_raster_bip \
+   "$DATA_FOLDER/landsat/srtm.tif" \
+   /usr/share/ossim/elevation/srtm/srtm.ras
 
 unset OSSIM_PREFS_FILE
 


### PR DESCRIPTION
Fixing:

- fix old url no longer available
- fix path to ossim executalbe
- removed intruction to generate ovr and histogram for landsat nc dataset (those data are not found on the live)
- adding landsat and srtm subdataset (9mb) used in ossim and jupyter quickstarter