### PR TITLE
Add RStudio

### DIFF
--- a/bin/install_rstudio-server.sh
+++ b/bin/install_rstudio-server.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Copyright (c) 2013-2016 The Open Source Geospatial Foundation.
+# Licensed under the GNU LGPL version >= 2.1.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 2.1 of the License,
+# or any later version.  This library is distributed in the hope that
+# it will be useful, but WITHOUT ANY WARRANTY, without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details, either
+# in the "LICENSE.LGPL.txt" file distributed with this software or at
+# web page "http://www.fsf.org/licenses/lgpl.html".
+#
+# About:
+# =====
+# This script will install RStudio
+
+./diskspace_probe.sh "`basename $0`" begin
+####
+
+if [ -z "$USER_NAME" ] ; then
+   USER_NAME="user"
+fi
+USER_HOME="/home/$USER_NAME"
+USER_DESKTOP="$USER_HOME/Desktop"
+BUILD_DIR=`pwd`
+
+sudo apt-get install gdebi-core
+wget https://download2.rstudio.org/rstudio-server-0.99.893-amd64.deb
+sudo dpkg -i rstudio-server-0.99.893-amd64.deb
+rm rstudio-server-0.99.893-amd64.deb
+ 
+####
+./diskspace_probe.sh "`basename $0`" end
+

--- a/bin/install_rstudio.sh
+++ b/bin/install_rstudio.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Copyright (c) 2013-2016 The Open Source Geospatial Foundation.
+# Licensed under the GNU LGPL version >= 2.1.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 2.1 of the License,
+# or any later version.  This library is distributed in the hope that
+# it will be useful, but WITHOUT ANY WARRANTY, without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details, either
+# in the "LICENSE.LGPL.txt" file distributed with this software or at
+# web page "http://www.fsf.org/licenses/lgpl.html".
+#
+# About:
+# =====
+# This script will install RStudio
+
+./diskspace_probe.sh "`basename $0`" begin
+####
+
+if [ -z "$USER_NAME" ] ; then
+   USER_NAME="user"
+fi
+USER_HOME="/home/$USER_NAME"
+USER_DESKTOP="$USER_HOME/Desktop"
+BUILD_DIR=`pwd`
+
+sudo apt-get install gdebi-core
+# wget https://download2.rstudio.org/rstudio-0.99.893-amd64.deb
+wget https://download1.rstudio.org/rstudio-0.99.893-amd64.deb
+sudo dpkg -i rstudio-0.99.893-amd64.deb
+rm rstudio-0.99.893-amd64.deb
+ 
+####
+./diskspace_probe.sh "`basename $0`" end
+

--- a/bin/install_rstudio.sh
+++ b/bin/install_rstudio.sh
@@ -28,7 +28,7 @@ BUILD_DIR=`pwd`
 
 sudo apt-get install gdebi-core
 # wget https://download2.rstudio.org/rstudio-0.99.893-amd64.deb
-wget https://download1.rstudio.org/rstudio-0.99.893-amd64.deb
+wget https://download1.rstudio.org/rstudio-0.99.903-amd64.deb
 sudo dpkg -i rstudio-0.99.893-amd64.deb
 rm rstudio-0.99.893-amd64.deb
  

--- a/bin/install_rstudio.sh
+++ b/bin/install_rstudio.sh
@@ -29,7 +29,7 @@ BUILD_DIR=`pwd`
 sudo apt-get install gdebi-core
 # wget https://download2.rstudio.org/rstudio-0.99.893-amd64.deb
 wget https://download1.rstudio.org/rstudio-0.99.903-amd64.deb
-sudo dpkg -i rstudio-0.99.893-amd64.deb
+sudo dpkg -i rstudio-0.99.903-amd64.deb
 rm rstudio-0.99.893-amd64.deb
  
 ####

--- a/bin/main.sh
+++ b/bin/main.sh
@@ -138,8 +138,6 @@ for SCRIPT in \
   ./install_leaflet.sh \
   ./install_R.sh \
   ./install_rstudio.sh \
-  #Uncomment the following line to install RStudio Server
-  #./install_rstudio-server.sh
   ./install_ossim.sh \
   ./install_osgearth.sh \
   ./install_spatialite.sh \

--- a/bin/main.sh
+++ b/bin/main.sh
@@ -137,6 +137,9 @@ for SCRIPT in \
   ./install_openlayers.sh \
   ./install_leaflet.sh \
   ./install_R.sh \
+  ./install_rstudio.sh \
+  #Uncomment the following line to install RStudio Server
+  #./install_rstudio-server.sh
   ./install_ossim.sh \
   ./install_osgearth.sh \
   ./install_spatialite.sh \


### PR DESCRIPTION
With some help I'm getting closer to figuring out how OSGeoLive works.

So I've had a bash at adding RStudio which I think will make teaching command line GIS much more user friendly. [mapview](https://github.com/environmentalinformatics-marburg/mapview) for example works natively in RStudio's viewer. There's more discussion of these issues here: http://lists.osgeo.org/pipermail/live-demo/2015-August/010456.html

I don't think it was definitively agreed, and there may be a few refinements needed with my install script (rstudio server is just added as a placeholder) so I imagine this PR will lead to discussion rather than a direct accept.
