### PR TITLE
Also install gmt-dcw for GMT.

### DIFF
--- a/bin/install_gmt.sh
+++ b/bin/install_gmt.sh
@@ -29,11 +29,11 @@ fi
 USER_HOME="/home/$USER_NAME"
 
 
-PACKAGES="gmt gmt-doc gmt-gshhs-low \
+PACKAGES="gmt gmt-doc gmt-dcw gmt-gshhs-low \
    gmt-examples gv"
 
-# pkg not installed to save 15mb disc space:
-#   gmt-doc-pdf gmt-gshhs-full gmt-gshhs-high gmt-tutorial gmt-tutorial-pdf
+# pkg not installed to save disc space:
+#   gmt-gshhg-full gmt-gshhg-high
 
 apt-get --assume-yes install $PACKAGES
 


### PR DESCRIPTION
The `gmt-dcw` package provides the Digital Chart of the World (DCW) for GMT, and should be installed alongside `gmt-gshhg`.

The `gmt` package recommends `gmt-gshhg-data | gmt-gshhg-low` & `gmt-dcw` and should be installed automatically when apt installs Recommends by default, which doesn't seem to be case for OSGeo-Live.
