### PR TITLE
Fix - Adding user to vboxsf group to permit to access to the shared folders

### DIFF
--- a/bin/setdown.sh
+++ b/bin/setdown.sh
@@ -41,7 +41,8 @@ VM="${PACKAGE_NAME}-$VERSION"
 if [ `grep -c 'adduser' /etc/rc.local` -eq 0 ] ; then
     sed -i -e 's|exit 0||' /etc/rc.local
 
-#   GRPS="audio dialout fuse plugdev pulse staff tomcat7 users www-data vboxsf "
+# Add 'user' to needed groups
+#   GRPS="audio dialout fuse plugdev pulse staff tomcat7 users www-data vboxsf"
 #bad smelling hack to mitigate the effects of #1104's race condition
     GRPS="users tomcat8 www-data staff fuse plugdev audio dialout pulse vboxsf"
 

--- a/bin/setdown.sh
+++ b/bin/setdown.sh
@@ -41,9 +41,9 @@ VM="${PACKAGE_NAME}-$VERSION"
 if [ `grep -c 'adduser' /etc/rc.local` -eq 0 ] ; then
     sed -i -e 's|exit 0||' /etc/rc.local
 
-#   GRPS="audio dialout fuse plugdev pulse staff tomcat7 users www-data"
+#   GRPS="audio dialout fuse plugdev pulse staff tomcat7 users www-data vboxsf "
 #bad smelling hack to mitigate the effects of #1104's race condition
-    GRPS="users tomcat8 www-data staff fuse plugdev audio dialout pulse"
+    GRPS="users tomcat8 www-data staff fuse plugdev audio dialout pulse vboxsf"
 
     for GRP in $GRPS ; do
        echo "adduser $USER_NAME $GRP" >> /etc/rc.local

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -94,6 +94,10 @@ apt-get install --yes wget less zip unzip bzip2 p7zip \
 # If running outside virtualbox the drivers will not be loaded
 apt-get install --yes virtualbox-guest-dkms virtualbox-guest-x11 virtualbox-guest-utils
 
+## Adding the user to vboxsf group to permit access to virtualbox 
+# shared folders at logon
+usermod -a -G vboxsf $USER_NAME
+
 # add /usr/local/lib to /etc/ld.so.conf if needed, then run ldconfig
 # FIXME: similar thing needed for man pages?
 if [ -d /etc/ld.so.conf.d ] ; then

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -85,7 +85,7 @@ apt-get install --yes wget less zip unzip bzip2 p7zip \
   ghostscript htop units gdebi fslint xkb-data \
   xfonts-100dpi xfonts-75dpi zenity
 
-# removed from list: 
+# removed from list:
 # cvs cvsutils fuseiso dlocate medit nedit a2ps netpbm qiv lynx mutt mc
 # xchat rxvt scrot arandr sgt-puzzles sopwith
 
@@ -93,10 +93,6 @@ apt-get install --yes wget less zip unzip bzip2 p7zip \
 # If running on virtualbox this will allow us to use full-screen/usb2/...
 # If running outside virtualbox the drivers will not be loaded
 apt-get install --yes virtualbox-guest-dkms virtualbox-guest-x11 virtualbox-guest-utils
-
-## Adding the user to vboxsf group to permit access to virtualbox 
-# shared folders at logon
-usermod -a -G vboxsf $USER_NAME
 
 # add /usr/local/lib to /etc/ld.so.conf if needed, then run ldconfig
 # FIXME: similar thing needed for man pages?


### PR DESCRIPTION
Adding user to vboxsf group to permit to access to the shared folders at log on.
Before that you had to add user to the group then log out and log in to use the virtualbox shared folder.
