### PR TITLE
Grant ordinary users write access to GeoServer resources created by install_geonode.sh

### DIFF
--- a/bin/install_geonode.sh
+++ b/bin/install_geonode.sh
@@ -181,6 +181,15 @@ echo "Stopping GeoServer"
 sleep 30;
 echo "Done"
 
+# GeoServer startup above will create files and directories
+# owned by root in the GeoServer directory. Ordinary users must
+# have write access to these to be able to start GeoServer.
+adduser "$USER_NAME" users
+chmod -R g+w "$GEOSERVER_PATH/data_dir"
+chmod -R g+w "$GEOSERVER_PATH/logs"
+chgrp -R users "$GEOSERVER_PATH/data_dir"
+chgrp -R users "$GEOSERVER_PATH/logs"
+
 # Make the apache user the owner of the required dirs.
 chown -R www-data:www-data /usr/lib/python2.7/dist-packages/geonode/
 


### PR DESCRIPTION
GeoServer was broken by the retirement of Cartaro, which was cleaning up after ```install_geonode.sh```. See discussion:
http://osgeo-org.1560.x6.nabble.com/Permissions-problems-with-GeoServer-td5298736.html