### PR TITLE
Set writable location for GeoServer NetCDF index files

### DIFF
--- a/bin/install_geoserver.sh
+++ b/bin/install_geoserver.sh
@@ -89,6 +89,11 @@ rm -f "$GS_HOME"/webapps/geoserver/WEB-INF/lib/jai_*.jar
 cat << EOF > "$GS_HOME/bin/start_admin.sh"
 #!/bin/sh
 
+# Writable location for GeoServer NetCDF index files
+NETCDF_DATA_DIR="\$HOME/.geoserver"
+mkdir -p "\$NETCDF_DATA_DIR"
+export JAVA_OPTS="-DNETCDF_DATA_DIR=\$NETCDF_DATA_DIR"
+
 $GS_HOME/bin/startup.sh &
 
 DELAY=40


### PR DESCRIPTION
GeoServer NetCDF writes hidden index files in the directory containing each NetCDF file, and fails horribly with unhelpful error messages when reading NetCDF files from directories to which it does not have write access. Yes, even just reading. The poorly-documented workaround is to specify another directory with the ```-DNETCDF_DATA_DIR``` Java system property. This pull request applies the workaround, placing index files in ```$HOME/.geoserver```, allowing sample NetCDF data already included in the OSGeo Live disk to be used without first having to copy it to a writeable directory.

Only ```start_admin.sh``` is adjusted. Anyone using ```startup.sh``` must make their own arrangements.