### PR TITLE
Add unversioned symlink to GeoServer home (used in quickstart)

### DIFF
--- a/bin/install_geoserver.sh
+++ b/bin/install_geoserver.sh
@@ -66,6 +66,10 @@ wget -c --progress=dot:mega \
 echo "Unpacking GeoServer in $GS_HOME"
 unzip -o -q "geoserver-$GS_VERSION-bin.zip" -d "$INSTALL_FOLDER"
 
+## add an unversioned symlink to GeoServer home (used in quickstart)
+if [ ! -e "$INSTALL_FOLDER/geoserver" ]; then
+  ln -s "$GS_HOME" "$INSTALL_FOLDER/geoserver"
+fi
 
 ###------------------------------------------
 ### Configure Application ###


### PR DESCRIPTION
Without this symlink, the quickstart would need to be updated every time GeoServer is upgraded.