### PR TITLE
Remove mention of DVD and GIS from welcome message

### DIFF
--- a/desktop-conf/welcome_message.txt
+++ b/desktop-conf/welcome_message.txt
@@ -1,4 +1,4 @@
-Welcome to the OSGeo Live GIS DVD.
+Welcome to OSGeo Live.
 
 
 See the road-sign Help icon on the Desktop for information about the        
@@ -34,4 +34,4 @@ The living FAQ can be found here:
 
 
 Happy mapping!
-The OSGeo Live GIS Team
+The OSGeo Live Team


### PR DESCRIPTION
The welcome message refers to "DVD" even when it is often not. I also propose removing "GIS" as I have never heard it used. I think OSGeo Live is a sufficiently distinctive brand.