### PR TITLE
Update GeoMoose to version 2.9.3.

### DIFF
--- a/bin/install_geomoose.sh
+++ b/bin/install_geomoose.sh
@@ -35,13 +35,13 @@ mkdir -p /tmp/build-geomoose
 
 cd /tmp/build-geomoose
 
-## Download and extract GeoMOOSE 2.9.2
+## Download and extract GeoMOOSE 2.9.3
 wget -c --tries=3 --progress=dot:mega \
-   "http://www.geomoose.org/downloads/geomoose-2.9.2.tar.gz"
+   "http://www.geomoose.org/downloads/geomoose-2.9.3.tar.gz"
 #wget -c --tries=3 --progress=dot:mega \
 #   "http://download.osgeo.org/livedvd/data/geomoose/geomoose-2.9.0.tar.gz"
 
-tar -xzf geomoose-2.9.2.tar.gz
+tar -xzf geomoose-2.9.3.tar.gz
 
 rm -rf /usr/local/geomoose
 
@@ -54,7 +54,7 @@ mv /tmp/build-geomoose/geomoose*/* .
 ## Setup htdocs directory to be available to apache
 ln -s /usr/local/geomoose/htdocs /var/www/html/geomoose
 
-## Configure GeoMOOSE 2.9.2
+## Configure GeoMOOSE 2.9.3
 cat > /usr/local/geomoose/conf/local_settings.ini <<'EOF'
 [paths]
 root=/usr/local/geomoose/maps/


### PR DESCRIPTION
This is a small fix for a security vulnerability in 2.9.2 that was disclosed to the GeoMoose team today.  I know it is likely too late for OSGeoLive 10.5.  The bug probably isn't a big deal in context of OSGeoLive (which is not meant to serve sites to the internet), but the GeoMoose team would like everyone to move to the latest version as soon as practical.