### PR TITLE
[uDig] fix unzip to UDIG_FOLDER

### DIFF
--- a/bin/install_udig.sh
+++ b/bin/install_udig.sh
@@ -116,7 +116,7 @@ else
    wget -c --progress=dot:mega "http://udig.refractions.net/files/downloads/$ZIP"
 fi
 # unpack to /usr/lib/udig
-unzip -q "$ZIP" -d "$INSTALL_FOLDER"
+unzip -q "$ZIP" -d "$UDIG_FOLDER"
 
 if [ $? -ne 0 ] ; then
    echo "ERROR: expanding $ZIP"


### PR DESCRIPTION
unzip to /usr/lib/udig because the zip doesn't contain neither a root folder udig nor a root folder with version info or something similiar