### PR TITLE
Update GeoMoose to version 3.1.0

### DIFF
--- a/bin/install_geomoose.sh
+++ b/bin/install_geomoose.sh
@@ -34,14 +34,14 @@ mkdir -p /tmp/build-geomoose
 
 cd /tmp/build-geomoose
 
-## Download and extract GeoMOOSE 3.1.0
+## Download and extract GeoMOOSE 3.2.0
 wget -c --tries=3 --progress=dot:mega --no-check-certificate \
-   "https://www.geomoose.org/downloads/gm3-examples-3.1.0.zip"
+   "https://www.geomoose.org/downloads/gm3-examples-3.2.0.zip"
 wget -c --tries=3 --progress=dot:mega --no-check-certificate \
-   "https://www.geomoose.org/downloads/gm3-demo-data-3.1.0.zip"
+   "https://www.geomoose.org/downloads/gm3-demo-data-3.2.0.zip"
 
-unzip gm3-examples-3.1.0.zip
-unzip gm3-demo-data-3.1.0.zip
+unzip gm3-examples-3.2.0.zip
+unzip gm3-demo-data-3.2.0.zip
 
 rm -rf /usr/local/geomoose
 
@@ -56,7 +56,7 @@ mv /tmp/build-geomoose/gm3-demo-data .
 rm -f /var/www/html/geomoose
 ln -s /usr/local/geomoose/gm3-examples/htdocs /var/www/html/geomoose
 
-## Configure GeoMOOSE 3.1.0
+## Configure GeoMOOSE 3.2.0
 cat > /usr/local/geomoose/gm3-examples/htdocs/desktop/config.js <<'EOF'
 CONFIG = {
     mapserver_url: "/cgi-bin/mapserv",

--- a/bin/install_geomoose.sh
+++ b/bin/install_geomoose.sh
@@ -18,14 +18,12 @@
 # web page "http://www.fsf.org/licenses/lgpl.html".
 #############################################################################
 
-# Requires: Apache2, PHP5, MapServer
+# Requires: Apache2, MapServer
 
 ./diskspace_probe.sh "`basename $0`" begin
 BUILD_DIR=`pwd`
 ####
 
-
-apt-get --assume-yes install php5.6 php5.6-sqlite3 php5.6-mbstring
 
 if [ -z "$USER_NAME" ] ; then
    USER_NAME="user"
@@ -36,13 +34,14 @@ mkdir -p /tmp/build-geomoose
 
 cd /tmp/build-geomoose
 
-## Download and extract GeoMOOSE 2.9.3
+## Download and extract GeoMOOSE 3.1.0
 wget -c --tries=3 --progress=dot:mega --no-check-certificate \
-   "http://www.geomoose.org/downloads/geomoose-2.9.3.tar.gz"
-#wget -c --tries=3 --progress=dot:mega \
-#   "http://download.osgeo.org/livedvd/data/geomoose/geomoose-2.9.0.tar.gz"
+   "https://www.geomoose.org/downloads/gm3-examples-3.1.0.zip"
+wget -c --tries=3 --progress=dot:mega --no-check-certificate \
+   "https://www.geomoose.org/downloads/gm3-demo-data-3.1.0.zip"
 
-tar -xzf geomoose-2.9.3.tar.gz
+unzip gm3-examples-3.1.0.zip
+unzip gm3-demo-data-3.1.0.zip
 
 rm -rf /usr/local/geomoose
 
@@ -50,26 +49,33 @@ mkdir -p /usr/local/geomoose
 
 cd /usr/local/geomoose
 
-mv /tmp/build-geomoose/geomoose*/* .
+mv /tmp/build-geomoose/gm3-examples .
+mv /tmp/build-geomoose/gm3-demo-data .
 
 ## Setup htdocs directory to be available to apache
-ln -s /usr/local/geomoose/htdocs /var/www/html/geomoose
+rm -f /var/www/html/geomoose
+ln -s /usr/local/geomoose/gm3-examples/htdocs /var/www/html/geomoose
 
-## Configure GeoMOOSE 2.9.3
-cat > /usr/local/geomoose/conf/local_settings.ini <<'EOF'
-[paths]
-root=/usr/local/geomoose/maps/
-mapserver_url=/cgi-bin/mapserv
-temp=/tmp/
+## Configure GeoMOOSE 3.1.0
+cat > /usr/local/geomoose/gm3-examples/htdocs/desktop/config.js <<'EOF'
+CONFIG = {
+    mapserver_url: "/cgi-bin/mapserv",
+    mapfile_root: "/usr/local/geomoose/gm3-demo-data/"
+};
 EOF
 
-cat > /usr/local/geomoose/maps/temp_directory.map <<'EOF'
+cat > /usr/local/geomoose/gm3-examples/htdocs/mobile/config.js <<'EOF'
+CONFIG = {
+    mapserver_url: "/cgi-bin/mapserv",
+    mapfile_root: "/usr/local/geomoose/gm3-demo-data/"
+};
+EOF
+
+cat > /usr/local/geomoose/gm3-demo-data/temp_directory.map <<'EOF'
 # This file is used to configure temporary directories for Mapserver Mapfile
 
 IMAGEPATH "/tmp/"
 
-# Remove the "#" before the next "IMAGEPATH" statement if you are using MS4W
-# IMAGEPATH "/ms4w/tmp/ms_tmp/"
 EOF
 
 ## Install icon
@@ -84,26 +90,27 @@ Fg+Ynx6BGPtddgAAAABJRU5ErkJggg==
 EOF
 
 ## Install menu and desktop shortcuts
-cat << EOF > /usr/share/applications/GeoMOOSE.desktop
+cat << EOF > /usr/share/applications/GeoMoose3.desktop
 [Desktop Entry]
 Version=1.0
 Encoding=UTF-8
 Type=Application
-Name=GeoMOOSE
-Comment=View GeoMOOSE sample application in browser
+Name=GeoMoose 3
+Comment=View GeoMoose sample application in browser
 Categories=Application;Geography;Geoscience;Education;
-Exec=sensible-browser http://localhost/geomoose/geomoose.html
+Exec=sensible-browser http://localhost/geomoose/desktop/index.html
 Icon=/usr/share/icons/geomoose.png
 Terminal=false
 StartupNotify=false
 EOF
 
-cp /usr/share/applications/GeoMOOSE.desktop "$USER_HOME"/Desktop/
-chown $USER_NAME:$USER_NAME "$USER_HOME/Desktop/GeoMOOSE.desktop"
+cp /usr/share/applications/GeoMoose3.desktop "$USER_HOME"/Desktop/
+chown $USER_NAME:$USER_NAME "$USER_HOME/Desktop/GeoMoose3.desktop"
 
 ## share data with the rest of the disc
 mkdir -p /usr/local/share/data/vector
-ln -s /usr/local/geomoose/maps/demo \
+rm -f /usr/local/share/data/vector/geomoose
+ln -s /usr/local/geomoose/gm3-demo-data \
       /usr/local/share/data/vector/geomoose
 
 

--- a/bin/install_icons_and_menus.sh
+++ b/bin/install_icons_and_menus.sh
@@ -52,7 +52,7 @@ WEB_SERVICES="deegree-* geoserver-* *geonetwork* mapserver mapproxy-*
 #disabled: mapguide*
 
 #Server apps part 2 (web based viewers; data only flows down to user)
-BROWSER_CLIENTS="openlayers cesium leaflet geomajas-* mapbender3 GeoMOOSE geonode-*"
+BROWSER_CLIENTS="openlayers cesium leaflet geomajas-* mapbender3 GeoMoose3 geonode-*"
 #disabled: i3geo MapFish-* cartaro-*
 
 #Infrastructure and miscellanea


### PR DESCRIPTION
GeoMoose 3.y has been in the wild for about 9 months and is the latest and greatest.  There will likely be a couple of minor releases worth incorporating before the June freeze, but I would like to get the major version updated early in the process.

Note: GeoMoose 3.y dropped the use of PHP and instead uses standard WFS calls and client side JavaScript, so the MapScript/PHP 7 issue no longer effects us.