### PR TITLE
Update uDig to version 2.0.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -25,7 +25,7 @@ Version 11.0beta1
  * Jupyter 4.2.0
  * OpenCPN 4.6.1
  * R 3.4.0
- * uDig 2.0.0RC1
+ * uDig 2.0.0.RC1
  * Zygrib 7.0.0
  * Django 1.8
  * OSM featured city now Boston

--- a/bin/install_udig.sh
+++ b/bin/install_udig.sh
@@ -45,7 +45,7 @@ USER_HOME="/home/$USER_NAME"
 
 TMP="/tmp/build_udig"
 INSTALL_FOLDER="/usr/lib"
-UDIG_VERSION="2.0.0.RC1"
+UDIG_VERSION="2.0.0"
 UDIG_FOLDER="$INSTALL_FOLDER/udig"
 DOCS_FOLDER="/usr/local/share/udig"
 DATA_GLOBAL="/usr/local/share/data"


### PR DESCRIPTION
Release-Notes and further details see : [uDig 2.0.0](https://github.com/locationtech/udig-platform/releases/tag/release%2F2.0.0)

**NOTE** : it requires Java 1.8++ which is already used on OSGeo Live I guess

Signed-off-by: Frank Gasdorf <Frank.Gasdorf@plath.de>