### PR TITLE
install rasdaman from official packages, rather than the installer

### DIFF
--- a/bin/install_rasdaman.sh
+++ b/bin/install_rasdaman.sh
@@ -25,14 +25,244 @@
 BUILD_DIR=`pwd`
 ####
 
-wget http://download.rasdaman.org/installer/install.sh
-sudo bash install.sh -p osgeo
+# NOTE: this script is executed with root
+if [ -z "$USER_NAME" ] ; then
+   USER_NAME="user"
+fi
+USER_HOME="/home/$USER_NAME"
+
+RMANHOME=/opt/rasdaman
+
+setup_rasdaman_repo()
+{
+  echo "Setup rasdaman package repository..."
+  # add rasdaman public key
+  local rasdaman_pkgs_url="http://download.rasdaman.org/packages"
+  wget -q -O - "$rasdaman_pkgs_url/rasdaman.gpg" | apt-key add - \
+    || { echo "Failed importing rasdaman GPG key."; return 1; }
+  # add rasdaman repo
+  local codename="$1"
+  local release="$2"
+  echo "deb [arch=amd64] $rasdaman_pkgs_url/deb $codename $release" > /etc/apt/sources.list.d/rasdaman.list
+}
+
+install_rasdaman_pkg()
+{
+  echo "Install rasdaman package..."
+  apt-get -qq update -y
+  # automate any configuration update dialog
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get -o Dpkg::Options::="--force-confdef" install -y rasdaman \
+    || { echo "Failed installing rasdaman package."; return 1; }
+  pip -q install glob2
+  # add rasdaman user to tomcat8 group
+  adduser rasdaman tomcat8
+  # and user to rasdaman group
+  adduser $USER_NAME rasdaman
+  echo
+  echo "Rasdaman package installed successfully."
+  echo
+}
+
+create_bin_starters()
+{
+  echo "Creating starting scripts..."
+  cat > $RMANHOME/bin/rasdaman-start.sh <<EOF
+#!/bin/bash
+sudo service tomcat8 start
+sudo service rasdaman start
+echo "Preparing demo data..."
+$RMANHOME/bin/rasdaman-osgeo-demo.sh &> /dev/null
+$RMANHOME/bin/petascope-osgeo-demo.sh &> /dev/null
+echo "Demo data prepared successfully."
+echo "Rasdaman was started correctly."
+EOF
+  cat > $RMANHOME/bin/rasdaman-stop.sh <<EOF
+#!/bin/bash
+sudo service tomcat8 stop
+sudo service rasdaman stop
+echo -e "Rasdaman stopped."
+EOF
+  chmod 755 $RMANHOME/bin/rasdaman-start.sh $RMANHOME/bin/rasdaman-stop.sh
+}
+
+create_demo_scripts()
+{
+  echo "Creating demo scripts..."
+  cat > $RMANHOME/bin/rasdaman-osgeo-demo.sh <<EOF
+#!/bin/bash
+rasdaman_demo_created="$RMANHOME/rasdaman_demo_success"
+if [ ! -f "\$rasdaman_demo_created" ]; then
+    echo "Ingesting rasdaman data..."
+    $RMANHOME/bin/rasdaman_insertdemo.sh localhost 7001 \
+      $RMANHOME/share/rasdaman/examples/images rasadmin rasadmin
+    sudo touch "\$rasdaman_demo_created"
+    echo "Rasdaman data ingested successfully."
+fi
+EOF
+  cat > $RMANHOME/bin/petascope-osgeo-demo.sh <<EOF
+#!/bin/bash
+petascope_demo_created=$RMANHOME/petascope_demo_success
+wcst_import="$RMANHOME/bin/wcst_import.sh"
+ingest_path="$RMANHOME/ingest"
+if [ ! -f "\$petascope_demo_created" ]; then
+    echo "Ingesting Petascope data..."
+    sudo $RMANHOME/bin/petascope_insertdemo.sh
+    for ingredients in NIR NN3_1 lena; do
+      sudo \$wcst_import \$ingest_path/\$ingredients.json
+    done
+    sudo touch "\$petascope_demo_created"
+    echo "Petascope data ingested successfully."
+fi
+EOF
+  chmod 755 $RMANHOME/bin/rasdaman-osgeo-demo.sh $RMANHOME/bin/petascope-osgeo-demo.sh
+}
+
+create_desktop_applications()
+{
+  echo "Creating desktop icons..."
+  for path in /usr/local/share/applications/ $USER_HOME/Desktop/; do
+    mkdir -p $path
+  cat > $path/start_rasdaman_server.desktop <<EOF
+[Desktop Entry]
+Type=Application
+Encoding=UTF-8
+Name=Start Rasdaman Server
+Comment=Start Rasdaman Server
+Categories=Application;Education;Geography;
+Exec=gksudo bash $RMANHOME/bin/rasdaman-start.sh
+Icon=gnome-globe
+Terminal=true
+StartupNotify=false
+EOF
+  cat > $path/stop_rasdaman_server.desktop <<EOF
+[Desktop Entry]
+Type=Application
+Encoding=UTF-8
+Name=Stop Rasdaman Server
+Comment=Stop Rasdaman Server
+Categories=Application;Education;Geography;
+Exec=gksudo bash $RMANHOME/bin/rasdaman-stop.sh
+Icon=gnome-globe
+Terminal=true
+StartupNotify=false
+EOF
+  cat > $path/rasdaman_earthlook_demo.desktop <<EOF
+[Desktop Entry]
+Type=Application
+Encoding=UTF-8
+Name=Rasdaman-Earthlook Demo
+Comment=Rasdaman Demo and Tutorial
+Categories=Application;Education;Geography;
+Exec=firefox http://localhost/rasdaman-demo/
+Icon=gnome-globe
+Terminal=false
+StartupNotify=false
+EOF
+
+    for f in $path/start_rasdaman_server.desktop $path/stop_rasdaman_server.desktop $path/rasdaman_earthlook_demo.desktop; do
+      chown $USER_NAME: $f
+      chmod 755 $f
+    done
+  done
+  chown $USER_NAME: $USER_HOME/Desktop/
+}
+
+delete_not_needed_files()
+{
+  # remove development stuff
+  for f in lib include share/rasdaman/war; do
+    rm -rf $RMANHOME/$f
+  done
+  # strip executables
+  for f in $RMANHOME/bin/*; do
+    strip $f > /dev/null 2>&1 || true
+  done
+}
+
+deploy_local_earthlook()
+{
+  echo "Deploying local earthlook..."
+  local tmp_dir=/tmp/earthlook
+  local data_url="http://kahlua.eecs.jacobs-university.de/~earthlook/osgeo/earthlook.tar.gz"
+
+  mkdir -p "$tmp_dir"
+  pushd "$tmp_dir" > /dev/null
+  # download data
+  wget -q "$data_url" -O earthlook.tar.gz
+  # extract
+  tar xzf earthlook.tar.gz
+  local rasdaman_demo_path="/var/www/html/rasdaman-demo"
+  rm -rf "$rasdaman_demo_path"
+  mkdir -p /var/www/html/
+  # deploy
+  mv public_html "$rasdaman_demo_path"
+  chmod 755 "$rasdaman_demo_path"
+  popd > /dev/null
+
+  rm -rf "$tmp_dir"
+}
+
+setup_ingestion_ingredients()
+{
+  echo "Creating ingestion ingredients for demo data..."
+  local ingest_dir=$RMANHOME/ingest
+  local coverage=
+  local ingredients=
+  mkdir -p "$ingest_dir"
+  for coverage in NIR NN3_1 lena; do
+    ingredients="$ingest_dir/$coverage.json"
+    cat > "$ingredients" <<EOF
+{
+  "config": {
+    "service_url": "http://localhost:8080/rasdaman/ows",
+    "tmp_directory": "/tmp/",
+    "crs_resolver": "http://localhost:8080/def/",
+    "default_crs": "http://localhost:8080/def/OGC/0/Index2D",
+    "mock": false,
+    "automated": true,
+    "subset_correction" : false
+  },
+  "input": {
+    "coverage_id": "$coverage"
+  },
+  "recipe": {
+    "name": "wcs_extract",
+    "options": {
+      "coverage_id" : "$coverage",
+      "wcs_endpoint" : "http://ows.rasdaman.org/rasdaman/ows"
+    }
+  }
+}
+EOF
+  done
+}
+
+add_rasdaman_path_to_bashrc()
+{
+  echo "Add rasdaman profile to the user's bashrc..."
+  echo "source /etc/profile.d/rasdaman.sh" >> "$USER_HOME/.bashrc"
+}
+
+#
+# Install and setup demos
+#
+
+# TODO: change nightly to stable once the bionic stable packages are available
+setup_rasdaman_repo "bionic" "nightly"
+install_rasdaman_pkg
+
 sudo service rasdaman stop
 sudo service tomcat8 stop
 
-# Patching the urls in the demo website
-sudo sed -i 's/flanche.com:9090/ows.rasdaman.org/g' /var/www/html/rasdaman-demo/demo/demo-frames/2d/app.js
-sudo sed -i 's/flanche.com:9090/ows.rasdaman.org/g' /var/www/html/rasdaman-demo/demo/demo-frames/ww3d/app.js
+create_bin_starters
+create_demo_scripts
+create_desktop_applications
+delete_not_needed_files
+deploy_local_earthlook
+setup_ingestion_ingredients
+add_rasdaman_path_to_bashrc
+
 
 echo "Rasdaman command log:"
 echo "==============================================="


### PR DESCRIPTION
Currently this installs the nightly packages. Once we release stable packages for bionic (should be around next week), I'll update the script.
Tested manually in an `ubuntu/bionic64` vagrant VM.