### PR TITLE
perm fixup on otbApplication dir

### DIFF
--- a/bin/install_otb.sh
+++ b/bin/install_otb.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 #############################################################################
 #
-# Purpose: This script will install Orfeo Tooblox including Monteverdi2 and 
+# Purpose: This script will install Orfeo Tooblox including Monteverdi2 and
 # OTB apps, assumes script is run with sudo privileges.
 #
 #############################################################################
-# Copyright (c) 2009-2016 The Open Source Geospatial Foundation and others.
+# Copyright (c) 2009-2018 The Open Source Geospatial Foundation and others.
 # Licensed under the GNU LGPL version >= 2.1.
 #
 # This library is free software; you can redistribute it and/or modify it
@@ -54,6 +54,8 @@ chown -R $USER_NAME.$USER_NAME "$USER_HOME/Desktop/monteverdi.desktop"
 ## 12dev  otb paths fix #1604
 echo 'export PYTHONPATH=$PYTHONPATH:/usr/lib/otb/python' >> "$USER_HOME/.bashrc"
 echo 'export ITK_AUTOLOAD_PATH=/usr/lib/otb/applications' >> "$USER_HOME/.bashrc"
+chgrp user /usr/lib/otb/python
+chmod 775 /usr/lib/otb/python
 
 ##---------------------------------
 

--- a/bin/install_otb.sh
+++ b/bin/install_otb.sh
@@ -54,8 +54,7 @@ chown -R $USER_NAME.$USER_NAME "$USER_HOME/Desktop/monteverdi.desktop"
 ## 12dev  otb paths fix #1604
 echo 'export PYTHONPATH=$PYTHONPATH:/usr/lib/otb/python' >> "$USER_HOME/.bashrc"
 echo 'export ITK_AUTOLOAD_PATH=/usr/lib/otb/applications' >> "$USER_HOME/.bashrc"
-chgrp user /usr/lib/otb/python
-chmod 775 /usr/lib/otb/python
+python -c 'import otbApplication'  ## import once to pre-compile
 
 ##---------------------------------
 

--- a/bin/install_otb.sh
+++ b/bin/install_otb.sh
@@ -54,7 +54,9 @@ chown -R $USER_NAME.$USER_NAME "$USER_HOME/Desktop/monteverdi.desktop"
 ## 12dev  otb paths fix #1604
 echo 'export PYTHONPATH=$PYTHONPATH:/usr/lib/otb/python' >> "$USER_HOME/.bashrc"
 echo 'export ITK_AUTOLOAD_PATH=/usr/lib/otb/applications' >> "$USER_HOME/.bashrc"
-python -c 'import otbApplication'  ## import once to pre-compile
+
+## import once to pre-compile
+python -c "import sys;sys.path.append('/usr/lib/otb/python');import otbApplication"
 
 ##---------------------------------
 


### PR DESCRIPTION
change one internal OTB python dir to writeable by user, required for python to init the interface by writing a dot-pyc