### PR TITLE
ipython typo

### DIFF
--- a/bin/install_R.sh
+++ b/bin/install_R.sh
@@ -98,6 +98,7 @@ apt-get install --yes r-cran-rpostgresql     ## installs only in /usr/lib/R ; li
 apt-get install --yes libudunits2-dev
 apt-get install --yes gfortran
 su - -c "R -e \"install.packages('udunits2')\""
+su - -c "R -e \"install.packages('ggplot2')\""
 su - -c "R -e \"install.packages('sf', repos='http://cran.rstudio.com/')\""
 su - -c "R -e \"install.packages('lwgeom', repos='http://cran.rstudio.com/')\""
 su - -c "R -e \"install.packages('wkb', repos='http://cran.rstudio.com/')\""

--- a/bin/setdown.sh
+++ b/bin/setdown.sh
@@ -129,7 +129,7 @@ rm dask/tests/*;
 rm django/test/*;
 rm dask/dataframe/io/tests/*;
 rm networkx/algorithms/flow/tests/*;
-rm IPython/testing/*;
+#rm IPython/testing/*;  ## ipython fails to start if rm'd
 rm geopandas/tests/*;
 rm jupyter_core/tests/*;
 rm pbr/tests/*;


### PR DESCRIPTION
ipython requires a `tests/` directory to start

