### PR TITLE
updated mapbender to 3.0.8 + no doc rm

### DIFF
--- a/bin/install_mapbender.sh
+++ b/bin/install_mapbender.sh
@@ -39,8 +39,8 @@ USER_HOME="/home/$USER_NAME"
 
 TMP_DIR="/tmp/build_mapbender"
 PARAMETERSINSTALLURL="https://www.mapbender.org/builds/osgeolive"
-INSTALLURL="http://www.mapbender.org/builds/3.0.7.3"
-INSTALLFILE="mapbender3-starter-3.0.7.3"
+INSTALLURL="http://www.mapbender.org/builds/3.0.8"
+INSTALLFILE="mapbender-starter-v3.0.8"
 PARAMETERSFILE="mapbender3-starter-3.0.6.2"
 INSTALL_DIR="/var/www/html"
 
@@ -94,10 +94,7 @@ cd "$INSTALL_DIR/mapbender/"
 rm  "$INSTALL_DIR/mapbender/app/config/parameters.yml"
 cp "$TMP_DIR/${PARAMETERSFILE}_parameters.yml"    "$INSTALL_DIR/mapbender/app/config/parameters.yml"
 
-sed -i -e 's/3.0.6.2/3.0.7.3/g' "$INSTALL_DIR/mapbender/app/config/parameters.yml"
-
-# remove documentation 
-rm -R "$INSTALL_DIR/mapbender/web/docs/"
+sed -i -e 's/3.0.6.2/3.0.8/g' "$INSTALL_DIR/mapbender/app/config/parameters.yml"
 
 app/console doctrine:database:create
 app/console doctrine:schema:create


### PR DESCRIPTION
* Updated Mapbender to version 3.0.8
* documentation is not part of the package anymore. So no need to delete it