### PR TITLE
Update Mapserver Demo link

### DIFF
--- a/bin/install_mapproxy.sh
+++ b/bin/install_mapproxy.sh
@@ -172,7 +172,7 @@ sources:
     req:
       url: http://localhost/cgi-bin/mapserv?
       layers: airports,cities,lakespy2,dlgstln2,roads,twprgpy3
-      map: /usr/local/www/docs_maps/mapserver_demos/workshop/itasca.map
+      map: /usr/local/www/docs_maps/mapserver_demos/itasca/itasca.map
     coverage:
       bbox: 363016.590190,5148502.940313,588593.999470,5374080.349593
       bbox_srs: 'epsg:26915'

--- a/bin/install_mapserver.sh
+++ b/bin/install_mapserver.sh
@@ -53,39 +53,35 @@ apt-get install --yes cgi-mapserver mapserver-bin python-mapscript
 # apt-get install --yes php-mapscript
 
 # Download MapServer data
-#wget -c --progress=dot:mega \
-#   "http://download.osgeo.org/livedvd/data/mapserver/mapserver-6-2-html-docs.zip"
+
+MS_DEMO_VERSION="1.0"
+MS_DOCS_VERSION="7-0"
 
 wget -c --progress=dot:mega \
-    "http://download.osgeo.org/livedvd/data/mapserver/mapserver-7-0-html-docs.zip"
+    "http://download.osgeo.org/livedvd/data/mapserver/mapserver-$MS_DOCS_VERSION-html-docs.zip"
 wget -c --progress=dot:mega \
-   "http://download.osgeo.org/livedvd/data/mapserver/mapserver-itasca-ms70.zip"
+   "https://github.com/mapserver/mapserver-demo/archive/v$MS_DEMO_VERSION.zip"
 
 # Install docs and demos
 if [ ! -d "$MAPSERVER_DATA" ] ; then
     mkdir -p "$MAPSERVER_DATA"/demos
 
     echo -n "Extracting MapServer html doc in $MAPSERVER_DATA/..."
-    unzip -q "$TMP_DIR/mapserver-7-0-html-docs.zip" -d "$MAPSERVER_DATA"/
-    echo -n "Done\nExtracting MapServer itasca demo in $MAPSERVER_DATA/demos/..."
-    unzip -q "$TMP_DIR/mapserver-itasca-ms70.zip" -d "$MAPSERVER_DATA"/demos/ 
+    unzip -qo "$TMP_DIR/mapserver-$MS_DOCS_VERSION-html-docs.zip"
+    mv "$TMP_DIR/mapserver-$MS_DOCS_VERSION-docs" "$MAPSERVER_DATA/doc"
+    rm -f "$TMP_DIR/mapserver-$MS_DOCS_VERSION-html-docs.zip"
     echo "Done"
 
-    mv "$MAPSERVER_DATA/demos/mapserver-demo-master" "$MAPSERVER_DATA/demos/itasca"
-    mv "$MAPSERVER_DATA/mapserver-7-0-docs" "$MAPSERVER_DATA/doc"
-    rm -rf "$MAPSERVER_DATA/demos/ms4w"
-
-    echo -n "Patching itasca.map to enable WMS..."
-    rm "$MAPSERVER_DATA"/demos/itasca/itasca.map
-    wget -c --progress=dot:mega \
-        "https://github.com/mapserver/mapserver-demo/raw/master/itasca.map" \
-        -O "$MAPSERVER_DATA"/demos/itasca/itasca.map
-    echo -n "Done"
+    echo -n "Extracting MapServer Itasca demo in $MAPSERVER_DATA/demos/..."
+    unzip -qo "$TMP_DIR/v$MS_DEMO_VERSION.zip"
+    mv "$TMP_DIR/mapserver-demo-$MS_DEMO_VERSION" "$MAPSERVER_DATA"/demos/itasca
+    rm -f "$TMP_DIR/v$MS_DEMO_VERSION.zip"
+    echo "Done"
 
     echo "Configuring the system...."
     # Itasca Demo hacks
     mkdir -p /usr/local/www/docs_maps/
-    ln -s "$MAPSERVER_DATA"/demos/itasca "$MAPSERVER_DATA"/demos/workshop
+    ln -s "$MAPSERVER_DATA"/demos/itasca "$MAPSERVER_DATA"/demos/workshop # for demo application
     ln -s /usr/local/share/mapserver/demos /usr/local/www/docs_maps/mapserver_demos
     ln -s /tmp /usr/local/www/docs_maps/tmp
     ln -s /tmp /var/www/html/tmp


### PR DESCRIPTION
This pull request installs the Itasca MapServer demo from a (newly) tagged release on GitHub (see https://github.com/mapserver/mapserver-demo/releases). 

The updated map includes the OSGeoLive hacks which can now be removed. The Itasca map also includes updates to work with the demo GeoExt application (see #257). 

The script allows version numbers to be more easily updated. 

Finally the mapproxy config has been updated to point to the non-symlinked version of the Itasca map. The symlink is still required for the MapServer CGI demo - this may be updated in the future to remove some of the symlinks setup by this script. 