### PR TITLE
Update MapServer Docs

### DIFF
--- a/bin/install_mapserver.sh
+++ b/bin/install_mapserver.sh
@@ -55,7 +55,7 @@ apt-get install --yes cgi-mapserver mapserver-bin python-mapscript
 # Download MapServer data
 
 MS_DEMO_VERSION="1.0"
-MS_DOCS_VERSION="7-0"
+MS_DOCS_VERSION="7-4"
 
 wget -c --progress=dot:mega \
     "http://download.osgeo.org/livedvd/data/mapserver/mapserver-$MS_DOCS_VERSION-html-docs.zip"
@@ -134,7 +134,7 @@ Encoding=UTF-8
 Name=Mapserver
 Comment=Mapserver
 Categories=Application;Education;Geography;
-Exec=firefox http://localhost/mapserver_demos/itasca/
+Exec=firefox http://localhost/mapserver_demos/itasca/ http://localhost/mapserver/doc/
 Icon=mapserver
 Terminal=false
 StartupNotify=false


### PR DESCRIPTION
Update the built HTML MapServer docs to the new 7.4 release.

Currently there seems no obvious way of finding these docs so the link will also open along with the demo when clicking on MapServer in the menu (this approach is used by a few other projects on OSGeoLive). 