### PR TITLE
Add the MapCache Project

### DIFF
--- a/app-conf/mapcache/index.html
+++ b/app-conf/mapcache/index.html
@@ -1,40 +1,37 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>Tiled WMS</title>
+<head>
+    <title>MapCache QuickStart Demo</title>
     <link rel="stylesheet" href="https://openlayers.org/en/v4.6.5/css/ol.css" type="text/css">
-    <!-- The line below is only needed for old environments like Internet Explorer and Android 4.x -->
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
     <script src="https://openlayers.org/en/v4.6.5/build/ol.js"></script>
-  </head>
-  <body>
+</head>
+<body>
     <div id="map" class="map"></div>
     <script>
-      var layers = [
-        new ol.layer.Tile({
-          source: new ol.source.OSM()
-        })
-        ,new ol.layer.Tile({
-		source: new ol.source.XYZ({
-			url: 'http://localhost/itasca/gmaps/ctybdpy2@GoogleMapsCompatible/{z}/{x}/{y}.png'
-        })
-      })
-       ,new ol.layer.Tile({
-         source: new ol.source.TileWMS({
-            url: 'http://localhost/itasca?',
-            params: {'LAYERS': 'lakespy2', 'TILED': true, 'TRANSPARENT': true, 'VERSION': '1.1.1'}
-          })
-        })
-
-      ];
-      var map = new ol.Map({
-        layers: layers,
-        target: 'map',
-        view: new ol.View({
-          center: ol.proj.fromLonLat([-93.33, 47.32]),
-          zoom: 6
-        })
-      });
+        var layers = [
+            new ol.layer.Tile({
+                opacity: 0.5,
+                source: new ol.source.OSM()
+            })
+            , new ol.layer.Tile({
+                source: new ol.source.XYZ({
+                    url: 'http://localhost/itasca/gmaps/lakes@GoogleMapsCompatible/{z}/{x}/{y}.png'
+                })
+            })
+            //, new ol.layer.Tile({
+            //    source: new ol.source.XYZ({
+            //        url: 'http://localhost/itasca/gmaps/streams@GoogleMapsCompatible/{z}/{x}/{y}.png'
+            //    })
+            //})
+        ];
+        var map = new ol.Map({
+            layers: layers,
+            target: 'map',
+            view: new ol.View({
+                center: ol.proj.fromLonLat([-93.33, 47.32]),
+                zoom: 10
+            })
+        });
     </script>
-  </body>
+</body>
 </html>

--- a/app-conf/mapcache/index.html
+++ b/app-conf/mapcache/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Tiled WMS</title>
+    <link rel="stylesheet" href="https://openlayers.org/en/v4.6.5/css/ol.css" type="text/css">
+    <!-- The line below is only needed for old environments like Internet Explorer and Android 4.x -->
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
+    <script src="https://openlayers.org/en/v4.6.5/build/ol.js"></script>
+  </head>
+  <body>
+    <div id="map" class="map"></div>
+    <script>
+      var layers = [
+        new ol.layer.Tile({
+          source: new ol.source.OSM()
+        })
+        ,new ol.layer.Tile({
+		source: new ol.source.XYZ({
+			url: 'http://localhost/itasca/gmaps/ctybdpy2@GoogleMapsCompatible/{z}/{x}/{y}.png'
+        })
+      })
+       ,new ol.layer.Tile({
+         source: new ol.source.TileWMS({
+            url: 'http://localhost/itasca?',
+            params: {'LAYERS': 'lakespy2', 'TILED': true, 'TRANSPARENT': true, 'VERSION': '1.1.1'}
+          })
+        })
+
+      ];
+      var map = new ol.Map({
+        layers: layers,
+        target: 'map',
+        view: new ol.View({
+          center: ol.proj.fromLonLat([-93.33, 47.32]),
+          zoom: 6
+        })
+      });
+    </script>
+  </body>
+</html>

--- a/app-conf/mapcache/index.html
+++ b/app-conf/mapcache/index.html
@@ -2,8 +2,8 @@
 <html>
 <head>
     <title>MapCache QuickStart Demo</title>
-    <link rel="stylesheet" href="https://openlayers.org/en/v4.6.5/css/ol.css" type="text/css">
-    <script src="https://openlayers.org/en/v4.6.5/build/ol.js"></script>
+    <link rel="stylesheet" href="http://localhost/geoext/ol.css" type="text/css" />
+    <script src="http://localhost/geoext/ol.js"></script>
 </head>
 <body>
     <div id="map" class="map"></div>

--- a/app-conf/mapcache/mapcache-quickstart.xml
+++ b/app-conf/mapcache/mapcache-quickstart.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mapcache>
+  <cache name="disk" type="disk">
+    <base>/home/user/mapcache/tilecache</base>
+    <symlink_blank/>
+  </cache>
+
+  <default_format>PNG</default_format>
+
+  <source name="lake_source" type="wms">
+    <getmap>
+      <params>
+        <FORMAT>image/png</FORMAT>
+        <LAYERS>lakespy2</LAYERS>
+        <MAP>/usr/local/www/docs_maps/mapserver_demos/itasca/itasca.map</MAP>
+      </params>
+    </getmap>
+    <http>
+      <url>http://localhost/cgi-bin/mapserv?</url>
+    </http>
+  </source>
+
+  <tileset name="lakes">
+    <source>lake_source</source>
+    <cache>disk</cache>
+    <grid>GoogleMapsCompatible</grid>
+    <format>PNG</format>
+  </tileset>
+
+  <service type="wms" enabled="true">
+    <full_wms>assemble</full_wms>
+    <resample_mode>bilinear</resample_mode>
+    <format>PNG</format>
+    <maxsize>4096</maxsize>
+    <forwarding_rule name="catch all">
+      <http>
+        <url>http://localhost/cgi-bin/mapserv?map=/usr/local/www/docs_maps/mapserver_demos/itasca/itasca.map&</url>
+      </http>
+    </forwarding_rule>
+  </service>
+  <service type="wmts" enabled="true"/>
+  <service type="tms" enabled="true"/>
+  <service type="kml" enabled="true"/>
+  <service type="gmaps" enabled="true"/>
+  <service type="ve" enabled="true"/>
+  <service type="mapguide" enabled="true"/>
+  <service type="demo" enabled="true"/>
+
+  <log_level>debug</log_level>
+
+  <errors>report</errors>
+  <locker type="disk">
+    <directory>/tmp</directory>
+    <timeout>300</timeout>
+  </locker>
+
+</mapcache>

--- a/app-conf/mapcache/mapcache-quickstart.xml
+++ b/app-conf/mapcache/mapcache-quickstart.xml
@@ -35,7 +35,7 @@
     <maxsize>4096</maxsize>
     <forwarding_rule name="catch all">
       <http>
-        <url>http://localhost/cgi-bin/mapserv?map=/usr/local/www/docs_maps/mapserver_demos/itasca/itasca.map&</url>
+        <url>http://localhost/cgi-bin/mapserv?map=/usr/local/www/docs_maps/mapserver_demos/itasca/itasca.map</url>
       </http>
     </forwarding_rule>
   </service>

--- a/bin/install_icons_and_menus.sh
+++ b/bin/install_icons_and_menus.sh
@@ -47,7 +47,7 @@ NAV_APPS="marble opencpn josm merkaartor osm_online
           zygrib gpsprune"
 
 #Server apps part 1 (web-enabled GIS; interactive/WPS)
-WEB_SERVICES="deegree-* geoserver-* *geonetwork* mapserver mapproxy-*
+WEB_SERVICES="deegree-* geoserver-* *geonetwork* mapserver mapcache mapproxy-*
               qgis-mapserver zoo-project 52n* eoxserver* ncWMS-* pycsw istsos pywps t-rex"
 #disabled: mapguide*
 

--- a/bin/install_mapcache.sh
+++ b/bin/install_mapcache.sh
@@ -1,0 +1,161 @@
+#!/bin/sh
+# Copyright (c) 2009-2019 The Open Source Geospatial Foundation and others.
+# Licensed under the GNU LGPL version >= 2.1.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 2.1 of the License,
+# or any later version.  This library is distributed in the hope that
+# it will be useful, but WITHOUT ANY WARRANTY, without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details, either
+# in the "LICENSE.LGPL.txt" file distributed with this software or at
+# web page "http://www.fsf.org/licenses/lgpl.html".
+#
+# About:
+# =====
+# This script will install mapcache
+#
+# Requires: Apache2
+#
+# Uninstall:
+# ============
+# sudo apt-get remove libmapcache1 mapcache-tools libapache2-mod-mapcache
+# sudo rm /etc/apache2/conf-available/mapserver
+# sudo rm -rf /usr/local/share/mapserver/
+# sudo rm -rf /usr/local/www/docs_maps
+
+./diskspace_probe.sh "`basename $0`" begin
+BUILD_DIR=`pwd`
+####
+
+
+# live disc's username is "user"
+if [ -z "$USER_NAME" ] ; then
+   USER_NAME="user"
+fi
+USER_HOME="/home/$USER_NAME"
+
+MAPSERVER_DATA="/usr/local/share/mapserver"
+
+MS_APACHE_CONF_FILE="mapserver.conf"
+APACHE_CONF_DIR="/etc/apache2/conf-available/"
+APACHE_CONF_ENABLED_DIR="/etc/apache2/conf-enabled/"
+MS_APACHE_CONF=$APACHE_CONF_DIR$MS_APACHE_CONF_FILE
+
+TMP_DIR=/tmp/build_mapserver
+mkdir "$TMP_DIR"
+cd "$TMP_DIR"
+
+# Install MapCache its command line tools and the MapCache Apache module
+# the Apache module adds /etc/apache2/mods-enabled/mapcache.load
+apt-get install --yes libmapcache1 mapcache-tools libapache2-mod-mapcache
+
+wget -c --progress=dot:mega \
+    "http://download.osgeo.org/livedvd/data/mapserver/mapserver-7-0-html-docs.zip"
+wget -c --progress=dot:mega \
+   "http://download.osgeo.org/livedvd/data/mapserver/mapserver-itasca-ms70.zip"
+
+# Install docs and demos
+if [ ! -d "$MAPSERVER_DATA" ] ; then
+    mkdir -p "$MAPSERVER_DATA"/demos
+
+    echo -n "Extracting MapServer html doc in $MAPSERVER_DATA/..."
+    unzip -q "$TMP_DIR/mapserver-7-0-html-docs.zip" -d "$MAPSERVER_DATA"/
+    echo -n "Done\nExtracting MapServer itasca demo in $MAPSERVER_DATA/demos/..."
+    unzip -q "$TMP_DIR/mapserver-itasca-ms70.zip" -d "$MAPSERVER_DATA"/demos/ 
+    echo "Done"
+
+    mv "$MAPSERVER_DATA/demos/mapserver-demo-master" "$MAPSERVER_DATA/demos/itasca"
+    mv "$MAPSERVER_DATA/mapserver-7-0-docs" "$MAPSERVER_DATA/doc"
+    rm -rf "$MAPSERVER_DATA/demos/ms4w"
+
+    echo -n "Patching itasca.map to enable WMS..."
+    rm "$MAPSERVER_DATA"/demos/itasca/itasca.map
+    wget -c --progress=dot:mega \
+        "https://github.com/mapserver/mapserver-demo/raw/master/itasca.map" \
+        -O "$MAPSERVER_DATA"/demos/itasca/itasca.map
+    echo -n "Done"
+
+    echo "Configuring the system...."
+    # Itasca Demo hacks
+    mkdir -p /usr/local/www/docs_maps/
+    ln -s "$MAPSERVER_DATA"/demos/itasca "$MAPSERVER_DATA"/demos/workshop
+    ln -s /usr/local/share/mapserver/demos /usr/local/www/docs_maps/mapserver_demos
+    ln -s /tmp /usr/local/www/docs_maps/tmp
+    ln -s /tmp /var/www/html/tmp
+fi
+
+
+# Add MapServer apache configuration
+cat << EOF > "$MS_APACHE_CONF"
+EnableSendfile off
+DirectoryIndex index.phtml
+Alias /mapserver "/usr/local/share/mapserver"
+Alias /ms_tmp "/tmp"
+Alias /tmp "/tmp"
+Alias /mapserver_demos "/usr/local/share/mapserver/demos"
+
+<Directory "/usr/local/share/mapserver">
+  Require all granted
+  Options +Indexes
+</Directory>
+
+<Directory "/usr/local/share/mapserver/demos">
+  Require all granted
+  Options +Indexes
+</Directory>
+
+<Directory "/tmp">
+  Require all granted
+  Options +Indexes
+</Directory>
+EOF
+
+# Make sure Apache has cgi-bin setup
+a2enmod cgi
+a2enconf $MS_APACHE_CONF_FILE
+echo "Finished configuring Apache"
+
+#Add Launch icon to desktop
+echo 'Downloading MapServer logo ...'
+mkdir -p /usr/local/share/icons
+wget -c --progress=dot:mega \
+   -O /usr/local/share/icons/mapcache.png \
+   "https://github.com/OSGeo/OSGeoLive-doc/raw/master/doc/images/projects/mapserver/logo_mapserver.png"
+
+cat << EOF > "/usr/share/applications/mapcache.desktop"
+[Desktop Entry]
+Type=Application
+Encoding=UTF-8
+Name=MapCache
+Comment=MapCache
+Categories=Application;Education;Geography;
+Exec=firefox http://localhost/mapcache/demo/
+Icon=mapcache
+Terminal=false
+StartupNotify=false
+Categories=Education;Geography;
+EOF
+
+
+cp /usr/share/applications/mapcache.desktop "$USER_HOME/Desktop/"
+chown "$USER_NAME.$USER_NAME" "$USER_HOME/Desktop/mapcache.desktop"
+
+
+# share data with the rest of the disc
+ln -s /usr/local/share/mapserver/demos/itasca/data \
+      /usr/local/share/data/itasca
+
+
+# Reload Apache
+#/etc/init.d/apache2 force-reload
+service apache2 --full-restart
+
+# cleanup
+cd "$MAPSERVER_DATA"/doc/_static/
+rm -rf `find | grep '/\.svn'`
+
+
+####
+"$BUILD_DIR"/diskspace_probe.sh "`basename $0`" end


### PR DESCRIPTION
This pull request installs MapCache from ubuntugis, along with the relevant files required for the quick start. 

Note the quick start requires OL4 and is loaded via a URL. Alternatives to this would be to install another copy of OL4 for MapCache, or use one installed from another project e.g. GeoExt. 

Overview and quickstart docs to follow and will be linked to from here. 