### PR TITLE
Update GeoStyler install script

### DIFF
--- a/bin/inchroot.sh
+++ b/bin/inchroot.sh
@@ -202,7 +202,7 @@ export USER_NAME
 ./install_cesium.sh
 ./install_geoext.sh
 ./install_rasdaman.sh
-# ./install_geostyler.sh
+./install_geostyler.sh
 # ./install_re3gistry.sh
 
 ## Docs, Data and extras

--- a/bin/install_geostyler.sh
+++ b/bin/install_geostyler.sh
@@ -32,56 +32,17 @@ if [ -z "$USER_NAME" ] ; then
 fi
 USER_HOME="/home/$USER_NAME"
 TMP_DIR="/tmp/build_geostyler"
-NVM_DIR="$USER_HOME/.nvm"
 
-
-GEOSTYLER_VERSION="4.5.0"
-GEOSTYLER_SLD_PARSER_VERSION="2.0.1"
-GEOSTYLER_OPENLAYERS_PARSER_VERSION="2.1.0"
-NVM_VERSION="0.35.3"
-NODE_VERSION="12"
-CREATE_REACT_APP_VERSION="3.4.1"
 GEOSTYLER_WORKSHOP_COMMIT="240e328d005666978038d8b89b1f3d8613e8d35e"
 GEOSTYLER_DIR=/var/www/html/geostyler
 
-#
-# Install nvm
-#
 echo "\nCreating temporary directory $TMP_DIR..."
 mkdir -p "$TMP_DIR"
 echo "\nCreating directory $GEOSTYLER_DIR..."
 mkdir -p "$GEOSTYLER_DIR"
 
 
-echo "\nDownloading nvm..."
 cd "$TMP_DIR"
-
-if [ -f "install_nvm.sh" ]
-then
-    echo "nvm has already been downloaded."
-else
-    cat > install_nvm.sh << EOF
-#!/bin/bash
-wget -qO- https://raw.githubusercontent.com/creationix/nvm/v$NVM_VERSION/install.sh | bash
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-echo "\nInstalling nodejs..."
-nvm install $NODE_VERSION
-echo "\nInstalling geostyler..."
-npm i -g geostyler@$GEOSTYLER_VERSION
-echo "\nInstalling geostyler-sld-parser..."
-npm i -g geostyler-sld-parser@$GEOSTYLER_SLD_PARSER_VERSION
-echo "\nInstalling geostyler-openlayers-parser..."
-npm i -g geostyler-openlayers-parser@$GEOSTYLER_OPENLAYERS_PARSER_VERSION
-echo "\nInstalling create-react-app..."
-npm i -g create-react-app@$CREATE_REACT_APP_VERSION
-EOF
-
-    chown $USER_NAME:$USER_NAME install_nvm.sh
-    chmod +x install_nvm.sh
-    cat install_nvm.sh
-    su $USER_NAME -c "./install_nvm.sh"
-fi
 
 echo "\nDownloading geostyler-workshop"
 GS_WORKSHOP_ARCHIVE="$GEOSTYLER_WORKSHOP_COMMIT.zip"


### PR DESCRIPTION
This removes the GeoStyler libraries and just keeps the beginner tutorial, as mentioned in https://github.com/OSGeo/OSGeoLive/pull/285#issuecomment-745987721.

