### PR TITLE
Update install_mapserver.sh

### DIFF
--- a/bin/install_mapserver.sh
+++ b/bin/install_mapserver.sh
@@ -97,6 +97,8 @@ Alias /ms_tmp "/tmp"
 Alias /tmp "/tmp"
 Alias /mapserver_demos "/usr/local/share/mapserver/demos"
 
+SetEnv MS_MAP_PATTERN "^\/usr\/local\/www\/docs_maps\/mapserver_demos\/([^\.][_A-Za-z0-9\-\.]+\/{1})*([_A-Za-z0-9\-\.]+\.(map))$"
+
 <Directory "/usr/local/share/mapserver">
   Require all granted
   Options +Indexes


### PR DESCRIPTION
Practice good configuration - set environment variable to restrict where MapServer CGI  can load a mapfile from. MapCache references the same configuration and should be ok too. --Steve