### PR TITLE
Update install_mapserver.sh to be a bit more liberal on where mapfiles can be read from.

### DIFF
--- a/bin/install_mapserver.sh
+++ b/bin/install_mapserver.sh
@@ -97,7 +97,7 @@ Alias /ms_tmp "/tmp"
 Alias /tmp "/tmp"
 Alias /mapserver_demos "/usr/local/share/mapserver/demos"
 
-SetEnv MS_MAP_PATTERN "^\/usr\/local\/www\/docs_maps\/mapserver_demos\/([^\.][_A-Za-z0-9\-\.]+\/{1})*([_A-Za-z0-9\-\.]+\.(map))$"
+SetEnv MS_MAP_PATTERN "^\/usr\/local\/([^\.][_A-Za-z0-9\-\.]+\/{1})*([_A-Za-z0-9\-\.]+\.(map))$"
 
 <Directory "/usr/local/share/mapserver">
   Require all granted


### PR DESCRIPTION
I think this will address ticket 2329. Allows mapfiles upstream of /usr/local and would cover both the MapServer/MapCache demo(s) and GeoMoose. Both examples below validate:

- /usr/local/geomoose/gm3-demo-data/test.map
- /usr/local/www/docs_maps/mapserver/demos/test.map

--Steve