### PR TITLE
Update install_mapserver.sh for ticket 2329.

### DIFF
--- a/bin/install_mapserver.sh
+++ b/bin/install_mapserver.sh
@@ -97,7 +97,8 @@ Alias /ms_tmp "/tmp"
 Alias /tmp "/tmp"
 Alias /mapserver_demos "/usr/local/share/mapserver/demos"
 
-SetEnv MS_MAP_PATTERN "^\/usr\/local\/([^\.][_A-Za-z0-9\-\.]+\/{1})*([_A-Za-z0-9\-\.]+\.(map))$"
+SetEnv MS_MAP_PATTERN "^\/usr\/local\/((\.\/)?|([^\.][_A-Za-z0-9\-\.]*\/{1}))*([_A-Za-z0-9\-\.]+\.(map))$"
+SetEnv MS_MAP_BAD_PATTERN "[/\\]{2}|[/\\]?\.{2,}[/\\]|,"
 
 <Directory "/usr/local/share/mapserver">
   Require all granted


### PR DESCRIPTION
Trying a new pattern to accommodate the /./ directory segments in the GeoMoose setup (see ticket 2329). Also preemptively included a pattern to allow /./ for newer versions of MapServer that do validation in two steps.

These pattern map values match:

- /usr/local/geomoose/gm3-demo-data/./demo/parcels/parcels.map
- /usr/local/geomoose/gm3-demo-data/demo/parcels/parcels.map
- /usr/local/mapserver/demo/itasca/itasca.map

--Steve