### PR TITLE
Update install_mapserver.sh (ticket 2329)

### DIFF
--- a/bin/install_mapserver.sh
+++ b/bin/install_mapserver.sh
@@ -97,7 +97,7 @@ Alias /ms_tmp "/tmp"
 Alias /tmp "/tmp"
 Alias /mapserver_demos "/usr/local/share/mapserver/demos"
 
-SetEnv MS_MAP_PATTERN "^\/usr\/local\/((\.\/)?|([^\.][_A-Za-z0-9\-\.]*\/{1}))*([_A-Za-z0-9\-\.]+\.(map))$"
+SetEnv MS_MAP_PATTERN "^\/usr\/local\/((\.\/)?|([^\.][-_A-Za-z0-9\.]*\/{1}))*([-_A-Za-z0-9\.]+\.(map))$"
 SetEnv MS_MAP_BAD_PATTERN "[/\\]{2}|[/\\]?\.{2,}[/\\]|,"
 
 <Directory "/usr/local/share/mapserver">


### PR DESCRIPTION
Version of regex library installed doesn't like \- in the character sets for directories and filenames. The regex compiles fine but doesn't evaluate correctly. Moving it as just - to the front of those character sets seems to fix things using the nightly OSGeo ISO.