### PR TITLE
Fetch/Install prebuilt gdal 3.4.3 libgdal-java components

### DIFF
--- a/bin/base_c.sh
+++ b/bin/base_c.sh
@@ -31,4 +31,12 @@ apt-get install --yes build-essential cmake pkg-config
 # Install OSGeo C stack libraries
 apt-get install --yes libgdal30 gdal-bin proj-bin libgeos-c1v5 geotiff-bin
 
+# Fetch/Install prebuilt libgdal-java components
+URL="https://sourceforge.net/projects/jump-pilot/files/OpenJUMP/osgeo/gdal-3.4.3+dfsg-java.20220622.tgz"
+FILE=/tmp/$(basename "$URL")
+wget --no-verbose -O "$FILE" "$URL" && \
+tar xvf "$FILE" -C / && \
+ls -la /usr/lib/jni/libgdalalljni.so /usr/share/java/gdal.jar && \
+rm "$FILE" || { echo "error installing gdal-java"; exit 1; }
+
 "$BUILD_DIR"/diskspace_probe.sh "`basename $0`" end


### PR DESCRIPTION
feel free to download/move the **updated install archive**. for ease of installation it contains the full paths where the files need to be located now. so using this updated 'gdal-3.4.3+dfsg-java.**20220622**.tgz' is mandatory for this PR to work!