### PR TITLE
Fix OTB build

### DIFF
--- a/bin/install_otb.sh
+++ b/bin/install_otb.sh
@@ -57,7 +57,7 @@ chown -R $USER_NAME.$USER_NAME "$USER_HOME/Desktop/monteverdi.desktop"
 echo 'export ITK_AUTOLOAD_PATH=/usr/lib/otb/applications' >> "$USER_HOME/.bashrc"
 
 ## import once to pre-compile
-python -c "import sys;sys.path.append('/usr/lib/otb/python');import otbApplication"
+python3 -c "import sys;sys.path.append('/usr/lib/otb/python');import otbApplication"
 
 ##---------------------------------
 
@@ -105,7 +105,7 @@ chown -R $USER_NAME.$USER_NAME "$USER_HOME/Desktop/otb-mapla.desktop"
 #     echo "Extracting OTB data examples $OTB_DATA/demos/..."
 #     tar xzf "$DATA_DIR/OTB-Data-Examples.tgz" -C $OTB_DATA/demos/
 #     echo "Done"
-fi
+# fi
 
 ####
 "$BUILD_DIR"/diskspace_probe.sh "`basename $0`" end


### PR DESCRIPTION
From https://trac.osgeo.org/osgeolive/ticket/2326#comment:6
> I forgot to mention, but there are the following errors in `chroot-build.log` in beta1.
```
===============================================================
Starting "install_otb.sh" ...
===============================================================
:
./install_otb.sh: 60: python: not found
./install_otb.sh: 108: Syntax error: "fi" unexpected
```
> Probably, changing `python` => `python3` on line:60 and commenting out `fi` on line:108 are necessary, but I will check those fix tonight.

Note that I haven't checked this changes locally... 🙇‍♂️