### PR TITLE
Change Running in Virtual Machine instructions in docs

### DIFF
--- a/bin/install_jupyter.sh
+++ b/bin/install_jupyter.sh
@@ -69,8 +69,9 @@ cp "$BUILD_DIR"/../app-data/jupyter/R_Notebooks_splash/RConsortium.png \
 ##-- o15  use git repo
 cd ${JUPYTER_BUILD_DIR}
 
-git clone https://github.com/OSGeo/OSGeoLive-Notebooks.git
+git clone --depth=1 https://github.com/OSGeo/OSGeoLive-Notebooks.git
 cp -R OSGeoLive-Notebooks/* ${USER_HOME}/jupyter/notebook_gallery/
+chown -R ${USER_NAME}:${USER_NAME}  ${USER_HOME}/jupyter/notebook_gallery/*
 rm -rf OSGeoLive-Notebooks
 
 

--- a/bin/install_jupyter.sh
+++ b/bin/install_jupyter.sh
@@ -66,17 +66,13 @@ cp "$BUILD_DIR"/../app-data/jupyter/R_Notebooks_splash/sf_logo.gif \
 cp "$BUILD_DIR"/../app-data/jupyter/R_Notebooks_splash/RConsortium.png \
    "$USER_HOME/jupyter/notebook_gallery/R/"
 
-##-- o14  copy tested content -dbb
+##-- o15  use git repo
 cd ${JUPYTER_BUILD_DIR}
-wget -c --progress=dot:mega \
-    -O OSGeoLive-Notebooks-14.x.zip \
-    https://github.com/OSGeo/OSGeoLive-Notebooks/archive/14.x.zip
-unzip -o -q OSGeoLive-Notebooks-14.x.zip
-cd OSGeoLive-Notebooks-14.x
-cp -R * ${USER_HOME}/jupyter/notebook_gallery/
-cd ..
-rm -rf OSGeoLive-Notebooks-14.x
-rm OSGeoLive-Notebooks-14.x.zip
+
+git clone https://github.com/OSGeo/OSGeoLive-Notebooks.git
+cp -R OSGeoLive-Notebooks/* ${USER_HOME}/jupyter/notebook_gallery/
+rm -rf OSGeoLive-Notebooks
+
 
 cd "$BUILD_DIR"
 rm -rf ${JUPYTER_BUILD_DIR}

--- a/bin/install_vm_only.sh
+++ b/bin/install_vm_only.sh
@@ -78,6 +78,7 @@ apt-get --yes install build-essential git gnupg devscripts debhelper \
 apt-get install --yes python-all-dev
 
 # misc notebook python3
+## TODO  lark_parser-0.12.0-py2.py3-none-any.whl  for datacube
 apt install python3-geoalchemy2 python3-datacube python3-cfgrib
 
 

--- a/bin/install_vm_only.sh
+++ b/bin/install_vm_only.sh
@@ -64,6 +64,8 @@ apt-get -q update
 apt-get --yes upgrade
 
 # Adding VBox guest additions
+#  note: requires multiverse repos
+#   https://packages.ubuntu.com/jammy/virtualbox-guest-x11
 apt-get install --yes virtualbox-guest-x11
 
 # Adding development packages that were removed from iso to save disk space
@@ -74,6 +76,10 @@ apt-get --yes install build-essential git gnupg devscripts debhelper \
 
 # Adding Python2
 apt-get install --yes python-all-dev
+
+# misc notebook python3
+apt install python3-geoalchemy2 python3-datacube python3-cfgrib
+
 
 # Adding back LibreOffice and other packages that were removed from iso to save disk space
 apt-get --yes install libreoffice libreoffice-common libreoffice-core 2048-qt noblenote trojita \


### PR DESCRIPTION
In the included docs under Running in a Virtual Machine, Step 3, the following sentence appears:

sudo apt-get install --yes virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11.  This is done to enable guest additions in a Virtualbox Virtual Machine.

Package virtualbox-guest-dkms has been removed in Ubuntu LTS (Jammy).

This entry can be safely removed from instructions., so it should just read sudo apt-get install --yes  virtualbox-guest-utils virtualbox-guest-x11