### PR TITLE
Update leaflet-demo with FOSS4G 2022 Firenze location

### DIFF
--- a/app-conf/leaflet/leaflet-demo.html
+++ b/app-conf/leaflet/leaflet-demo.html
@@ -14,15 +14,15 @@
 
     <script src="/leaflet/leaflet.js"></script>
     <script>
-        var map = L.map('map').setView([44.43743, 26.104], 15);
+        var map = L.map('map').setView([43.77913, 11.24938], 15);
 
         L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{}).addTo(map);
         //In case we are offline, start TileStache to get a base layer
         L.tileLayer('http://localhost:8012/example/{z}/{x}/{y}.png',{}).addTo(map);
 
-        var marker = L.marker([44.437 ,26.104]).addTo(map);            
+        var marker = L.marker([43.77913, 11.24938]).addTo(map);            
 
-        var circle = L.circle([44.435, 26.11], 250, {
+        var circle = L.circle([43.777, 11.255], 250, {
            color: 'red',
            fillColor: '#f03',
            fillOpacity: 0.5
@@ -30,13 +30,13 @@
         
         
         var polygon = L.polygon([
-           [44.433, 26.102],
-           [44.442, 26.095],
-           [44.436, 26.093]
+           [43.775, 11.247],
+           [43.784, 11.240],
+           [43.778, 11.238]
         ]).addTo(map);
         
         var popup = L.popup()
-           .setLatLng([44.437, 26.104])
+           .setLatLng([43.77913, 11.24938])
            .setContent("FOSS4G is here this year!")
            .openOn(map);
 


### PR DESCRIPTION
I shifted the coordinates to FOSS4G 2022 Firenze location.
![leaflet-demo-firenze](https://user-images.githubusercontent.com/629923/182019361-4505e129-841d-4bab-b42e-cfd240656663.png)

About the marker location, I picked the value from the following official site's uMap attributes.

- https://2022.foss4g.org/
  - Bottom Left Map:
    - <img src="https://user-images.githubusercontent.com/629923/182019444-d95d3365-8987-4b12-ab72-0b97209d39ca.png" width="200px" alt="2022-foss4g-org-bottom-left-map-url" />
  - https://umap.openstreetmap.fr/it/map/foss4g-2022-sites_776000#14/43.7867/11.2554
    - https://umap.openstreetmap.fr/ajax-proxy/?url=https%3A%2F%2F2022.foss4g.org%2Ffoss4g2022_venues.geojson&ttl=
      ```json
      {
          "type": "FeatureCollection",
          "features": [
            {
              "type": "Feature",
              "properties": {
                "venue": "Firenze Fiera Congress & Exhibition Center",
                "event": "Keynotes, speeches and main events",
                "url": "https://2022.foss4g.org/schedule_general.php"
              },
              "geometry": {
                "type": "Point",
                "coordinates": [
                  11.2493762,
                  43.7791291
                ]
              }
            },
            :
      ```
 