### PR TITLE
Adjust leaflet-demo with adding mapnik tile cached layer to mapproxy.yaml

### DIFF
--- a/app-conf/leaflet/leaflet-demo.html
+++ b/app-conf/leaflet/leaflet-demo.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link rel="stylesheet" href="/leaflet/leaflet.css" />
-    <!--[if lte IE 8]><link rel="stylesheet" href="../dist/leaflet.ie.css" /><![endif]-->
 </head>
 <body>
     <div id="map" style="width: 600px; height: 400px"></div>
@@ -17,8 +16,8 @@
         var map = L.map('map').setView([43.77913, 11.24938], 15);
 
         L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{}).addTo(map);
-        //In case we are offline, start TileStache to get a base layer
-        L.tileLayer('http://localhost:8012/example/{z}/{x}/{y}.png',{}).addTo(map);
+        //In case we are offline, start MapProxy to get a base layer
+        L.tileLayer('http://localhost:8011/wmts/mapnik_tile/GLOBAL_WEBMERCATOR/{z}/{x}/{y}.png',{}).addTo(map);
 
         var marker = L.marker([43.77913, 11.24938]).addTo(map);            
 

--- a/bin/install_mapproxy.sh
+++ b/bin/install_mapproxy.sh
@@ -124,6 +124,9 @@ layers:
   - name: mapnik
     title: World population (Mapnik)
     sources: [mapnik]
+  - name: mapnik_tile
+    title: World population (Mapnik, tile cached)
+    sources: [mapnik_cache]
   - name: mapserver
     title: Mapserver (Itasca)
     sources: [mapserver]
@@ -136,8 +139,8 @@ layers:
 
 caches:
   mapnik_cache:
-    grids: [GLOBAL_MERCATOR]
-    sources: [tilestache]
+    grids: [GLOBAL_WEBMERCATOR]
+    sources: [mapnik]
 
 sources:
   geoserver:


### PR DESCRIPTION
This PR is for Leaflet quickstart document update.
https://trac.osgeo.org/osgeolive/ticket/2388

- Delete IE 8 stylesheet line
- Add mapnik tile cached layer to `mapproxy.yaml`
- Replaced Leaflet local tile layer from TileStache to MapProxy mapnik tile layer