### PR TITLE
Bump MapServer docs version

### DIFF
--- a/bin/install_mapserver.sh
+++ b/bin/install_mapserver.sh
@@ -55,7 +55,7 @@ apt-get install --yes cgi-mapserver mapserver-bin python3-mapscript
 # Download MapServer data
 
 MS_DEMO_VERSION="1.1"
-MS_DOCS_VERSION="7-4"
+MS_DOCS_VERSION="7-6"
 
 wget -c --progress=dot:mega \
     "http://download.osgeo.org/livedvd/data/mapserver/mapserver-$MS_DOCS_VERSION-html-docs.zip"


### PR DESCRIPTION
Update docs to match installed version. The file http://download.osgeo.org/livedvd/data/mapserver/mapserver-7-6-html-docs.zip does exist.