### PR TITLE
Updates for Mapserver 8.0

### DIFF
--- a/app-conf/mapserver/mapserver.conf
+++ b/app-conf/mapserver/mapserver.conf
@@ -1,7 +1,8 @@
 CONFIG
   ENV
-    MS_MAP_PATTERN "."
-    PROJ_LIB" "/usr/share/proj"
+    MS_MAP_PATTERN "^\/usr\/local\/((\.\/)?|([^\.][-_A-Za-z0-9\.]*\/{1}))*([-_A-Za-z0-9\.]+\.(map))$"
+    MS_MAP_BAD_PATTERN "[/\\]{2}|[/\\]?\.{2,}[/\\]|,"
+    # PROJ_LIB" "/usr/share/proj"
     OGCAPI_HTML_TEMPLATE_DIRECTORY "/usr/share/mapserver/ogcapi/templates/html-plain/"
   END
 

--- a/app-conf/mapserver/mapserver.conf
+++ b/app-conf/mapserver/mapserver.conf
@@ -1,0 +1,11 @@
+CONFIG
+  ENV
+    MS_MAP_PATTERN "."
+    PROJ_LIB" "/usr/share/proj"
+    OGCAPI_HTML_TEMPLATE_DIRECTORY "/usr/share/mapserver/ogcapi/templates/html-plain/"
+  END
+
+  MAPS
+    ITASCA "/usr/local/www/docs_maps/mapserver_demos/itasca/itasca.map"
+  END
+END

--- a/bin/install_mapserver.sh
+++ b/bin/install_mapserver.sh
@@ -20,7 +20,7 @@
 #
 # Uninstall:
 # ============
-# sudo apt-get remove cgi-mapserver mapserver-bin php-mapscript python-mapscript
+# sudo apt-get remove cgi-mapserver mapserver-bin python3-mapscript php-mapscript-ng
 # sudo rm /etc/apache2/conf-available/mapserver
 # sudo rm -rf /usr/local/share/mapserver/
 # sudo rm -rf /usr/local/www/docs_maps
@@ -36,6 +36,9 @@ if [ -z "$USER_NAME" ] ; then
 fi
 USER_HOME="/home/$USER_NAME"
 
+# copy MapServer CONFIG file to its default location in /etc
+cp -f "$BUILD_DIR/../app-conf/mapserver/mapserver.conf" "/etc/mapserver.conf"
+
 MAPSERVER_DATA="/usr/local/share/mapserver"
 
 MS_APACHE_CONF_FILE="mapserver.conf"
@@ -48,13 +51,11 @@ mkdir "$TMP_DIR"
 cd "$TMP_DIR"
 
 # Install MapServer and its php, python bindings.
-apt-get install --yes cgi-mapserver mapserver-bin python3-mapscript
-# PHP 7.x not yet supported on MapServer 7.x
-# apt-get install --yes php-mapscript
+apt-get install --yes cgi-mapserver mapserver-bin python3-mapscript php-mapscript-ng
 
 # Download MapServer data
 
-MS_DEMO_VERSION="1.1"
+MS_DEMO_VERSION="1.2"
 MS_DOCS_VERSION="7-6"
 
 wget -c --progress=dot:mega \

--- a/bin/install_mapserver.sh
+++ b/bin/install_mapserver.sh
@@ -98,9 +98,6 @@ Alias /ms_tmp "/tmp"
 Alias /tmp "/tmp"
 Alias /mapserver_demos "/usr/local/share/mapserver/demos"
 
-SetEnv MS_MAP_PATTERN "^\/usr\/local\/((\.\/)?|([^\.][-_A-Za-z0-9\.]*\/{1}))*([-_A-Za-z0-9\.]+\.(map))$"
-SetEnv MS_MAP_BAD_PATTERN "[/\\]{2}|[/\\]?\.{2,}[/\\]|,"
-
 <Directory "/usr/local/share/mapserver">
   Require all granted
   Options +Indexes


### PR DESCRIPTION
This pull requests includes the following:

- points to the new updated demo (see https://github.com/MapServer/MapServer-demo/pull/7 - a new v1.2 tag was created for this
- adds a new CONFIG file required for MapServer 8.0. Move the current environment variables from Apache to the CONFIG file
- adds a new ITASCA setting to the CONFIG file (so it can be used for the OGC Features API - can add some notes to the quickstart on this)
- adds in the new `php-mapscript-ng` module

Note these changes haven't been tested with a full build of the OSGeoLive ISO, so there may need to be tweaks after a new beta build. 

TODO:

- [ ] the Itasca demo is currently broken until the `TEMPLATE` value can be set via a URL. See https://github.com/MapServer/MapServer/pull/6469#issuecomment-1375928613. Once this is merged and backported hopefully there can be a new MapServer 8.0 patch release used for OSGeoLive?
- [ ] confirm if the `PROJ_LIB" "/usr/share/proj"` setting in the CONFIG is required - or is this the default location anyway?
- [ ] update `MS_DOCS_VERSION="7-6"` to `MS_DOCS_VERSION="8-0"` when this file is available. It needs to be uploaded to http://download.osgeo.org/livedvd/data/mapserver/mapserver-8-0-html-docs.zip (see directory contents at http://download.osgeo.org/livedvd/data/mapserver/)
- [ ] it would be nice to include the `html-bootstrap4` templates - currently only `html-plain` are added in the UbuntuGIS package
