### PR TITLE
Updates to MapServer 8.0 setup

### DIFF
--- a/app-conf/mapserver/mapserver.conf
+++ b/app-conf/mapserver/mapserver.conf
@@ -2,7 +2,6 @@ CONFIG
   ENV
     MS_MAP_PATTERN "^\/usr\/local\/((\.\/)?|([^\.][-_A-Za-z0-9\.]*\/{1}))*([-_A-Za-z0-9\.]+\.(map))$"
     MS_MAP_BAD_PATTERN "[/\\]{2}|[/\\]?\.{2,}[/\\]|,"
-    # PROJ_LIB" "/usr/share/proj"
     OGCAPI_HTML_TEMPLATE_DIRECTORY "/usr/share/mapserver/ogcapi/templates/html-plain/"
   END
 

--- a/bin/install_mapserver.sh
+++ b/bin/install_mapserver.sh
@@ -56,7 +56,7 @@ apt-get install --yes cgi-mapserver mapserver-bin python3-mapscript php-mapscrip
 # Download MapServer data
 
 MS_DEMO_VERSION="1.2"
-MS_DOCS_VERSION="7-6"
+MS_DOCS_VERSION="8-0"
 
 wget -c --progress=dot:mega \
     "http://download.osgeo.org/livedvd/data/mapserver/mapserver-$MS_DOCS_VERSION-html-docs.zip"


### PR DESCRIPTION
A couple of minor updates following testing on the new `osgeolive-nightly-build28-amd64-20c99ee-master.iso` release. 

I've uploaded the latest docs to https://www.dropbox.com/s/oo9sulhheac7ejw/mapserver-8-0-html-docs.zip?dl=0 using the same naming convention / structure as previously. 

@kalxas do you have permissions to upload this file to http://download.osgeo.org/livedvd/data/mapserver/ ?

Once that zip is in place this pull request can be merged to update to the 8.0 MapServer docs. 

- `PROJ_LIB` setting in the `CONFIG` file has been removed as this location is a default anyway

I tested the new demo updates with the OGC Features API available in MapServer 8.0 and it seems to be working fine with the plain templates. Sample URLs:

+ http://locahost/cgi-bin/mapserv/itasca/ogcapi/ 
+ http://locahost/cgi-bin/mapserv/itasca/ogcapi/collections/lakespy2/items?f=html 
