### PR TITLE
Add qfield installation

### DIFF
--- a/bin/install_qfield.sh
+++ b/bin/install_qfield.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+#############################################################################
+#
+# Purpose: This script will install QGIS including Python and GRASS support,
+#
+#############################################################################
+# Copyright (c) 2009-2023 The Open Source Geospatial Foundation and others.
+# Licensed under the GNU LGPL version >= 2.1.
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 2.1 of the License,
+# or any later version.  This library is distributed in the hope that
+# it will be useful, but WITHOUT ANY WARRANTY, without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details, either
+# in the "LICENSE.LGPL.txt" file distributed with this software or at
+# web page "http://www.fsf.org/licenses/lgpl.html".
+#############################################################################
+
+QFIELD_VERSION=v2.7.5
+
+./diskspace_probe.sh "`basename $0`" begin
+BUILD_DIR=`pwd`
+####
+
+
+if [ -z "$USER_NAME" ] ; then
+   USER_NAME="user"
+fi
+USER_HOME="/home/$USER_NAME"
+
+mkdir -p/usr/local/bin
+wget -c --progress=dot:mega \
+  https://github.com/opengisch/QField/releases/download/${QFIELD_VERSION}/qfield-${QFIELD_VERSION}-linux-x64.AppImage \
+  -O /usr/local/bin/qfield
+chmod +x /usr/local/bin/qfield
+
+mkdir -p /usr/local/share/icons
+wget -c --progress=dot:mega \
+  https://github.com/opengisch/QField/raw/${QFIELD_VERSION}/images/icons/qfield_logo.svg \
+  -O /usr/local/share/icons/qfield_logo.svg
+
+#### install desktop icon ####
+if [ ! -e /usr/share/applications/ch.opengis.qfield.desktop ] ; then
+   cat << EOF > /usr/share/applications/ch.opengis.qfield.desktop
+[Desktop Entry]
+Type=Application
+Encoding=UTF-8
+Name=QField
+Comment=QField $QFIELD_VERSION
+Categories=Application;Education;Geography;
+Exec=/usr/local/bin/qfield %F
+Icon=/usr/local/share/icons/qfield_logo.svg
+Terminal=false
+StartupNotify=false
+Categories=Education;Geography;Qt;
+MimeType=application/x-qgis-project;image/tiff;image/jpeg;image/jp2;application/x-raster-aig;application/x-mapinfo-mif;application/x-esri-shape;
+EOF
+fi
+
+cp /usr/share/applications/ch.opengis.qfield.desktop "$USER_HOME/Desktop/qfield.desktop"
+chown -R $USER_NAME.$USER_NAME "$USER_HOME/Desktop/qfield.desktop"
+
+
+# add menu item
+if [ ! -e /usr/share/menu/qfield ] ; then
+   cat << EOF > /usr/share/menu/qfield
+?package(qfield):needs="X11"\
+  section="Applications/Science/Geoscience"\
+  title="QField"\
+  command="/usr/local/bin/qfield"\
+  icon="/usr/local/share/icons/qfield_logo.svg"
+EOF
+  update-menus
+fi
+
+####
+"$BUILD_DIR"/diskspace_probe.sh "`basename $0`" end


### PR DESCRIPTION
As discussed on the mailing list, this adds an installer for QField.
I wasn't able to test it, I just ran it in a simple `ubuntu:22.04` environment to check if it runs through. It might need some fine tuning with dependencies.

<details><summary>This installs an AppImage build that is built as part of the release CI pipelines. Read more about alternatives</summary>

This includes all dependencies required for QField. The [build pipeline lives here](https://github.com/opengisch/QField/blob/master/.github/workflows/linux.yml)

I have looked into some alternatives

1. building with the installed QGIS as dependency, however any recent QField version requires more recent versions of QField and installing an older version would sacrifice a lot of bugfixes that have landed in the last couple of months. So this option would be a pity.
2. I have also tried to build a .deb file with all dependencies included as a ppa, however this needs the build process on the ppa to pull in additional dependencies via git at build time via Internet and this is not allowed.
3. The deb from 2. could also be built somewhere else than in a ppa, but I don't see many advantages of that over the current approach with the AppImage.