### PR TITLE
[qfield] Install fuse, otherwise it will not run

### DIFF
--- a/bin/install_qfield.sh
+++ b/bin/install_qfield.sh
@@ -55,7 +55,7 @@ Encoding=UTF-8
 Name=QField
 Comment=QField $QFIELD_VERSION
 Categories=Application;Education;Geography;
-Exec=/usr/local/bin/qfield %F
+Exec=env FONTCONFIG_PATH=/etc/fonts /usr/local/bin/qfield %F
 Icon=/usr/local/share/icons/qfield_logo.svg
 Terminal=false
 StartupNotify=false

--- a/bin/install_qfield.sh
+++ b/bin/install_qfield.sh
@@ -35,7 +35,7 @@ apt-get -q update
 #Install fuse, required for loading AppImage
 apt-get --assume-yes install fuse
 
-mkdir -p/usr/local/bin
+mkdir -p /usr/local/bin
 wget -c --progress=dot:mega \
   https://github.com/opengisch/QField/releases/download/${QFIELD_VERSION}/qfield-${QFIELD_VERSION}-linux-x64.AppImage \
   -O /usr/local/bin/qfield

--- a/bin/install_qfield.sh
+++ b/bin/install_qfield.sh
@@ -30,6 +30,11 @@ if [ -z "$USER_NAME" ] ; then
 fi
 USER_HOME="/home/$USER_NAME"
 
+apt-get -q update
+
+#Install fuse, required for loading AppImage
+apt-get --assume-yes install fuse
+
 mkdir -p/usr/local/bin
 wget -c --progress=dot:mega \
   https://github.com/opengisch/QField/releases/download/${QFIELD_VERSION}/qfield-${QFIELD_VERSION}-linux-x64.AppImage \

--- a/bin/install_qfield.sh
+++ b/bin/install_qfield.sh
@@ -18,7 +18,7 @@
 # web page "http://www.fsf.org/licenses/lgpl.html".
 #############################################################################
 
-QFIELD_VERSION=v2.7.5
+QFIELD_VERSION=v2.7.6
 
 ./diskspace_probe.sh "`basename $0`" begin
 BUILD_DIR=`pwd`


### PR DESCRIPTION
This fixes various things in QField:

1. Install fuse which is required to run AppImage
2. Configure fonts correctly (monospace fonts are cool to code, but not everywhere)
3. Avoid a ~1 minute freeze on startup caused by waiting for bluetooth devices