### PR TITLE
Upgrade base Lubuntu ISO image to 22.04.2 with removing unnecessary packages and caches

### DIFF
--- a/bin/build_chroot.sh
+++ b/bin/build_chroot.sh
@@ -133,7 +133,7 @@ cd "$BUILD_HOME"/livecdtmp
 #mv ubuntu-9.04-desktop-i386.iso ~/livecdtmp
 UBU_MIRROR="http://cdimage.ubuntu.com"
 UBU_RELEASE="22.04"
-ISO_RELEASE="22.04.1"
+ISO_RELEASE="22.04.2"
 # ISO_RELEASE="22.04-beta"
 UBU_ISO="lubuntu-${ISO_RELEASE}-desktop-$ARCH.iso"
 wget -c --progress=dot:mega \

--- a/bin/setdown.sh
+++ b/bin/setdown.sh
@@ -215,6 +215,7 @@ EOF
 
 # remove the apt-get cache
 apt-get clean
+rm -rf /var/lib/apt/lists/*
 
 # This might be needed in the future when more kernels get included in .x releases
 # echo "linux-image-generic-hwe-16.04 install" | dpkg --set-selections

--- a/bin/setdown.sh
+++ b/bin/setdown.sh
@@ -76,7 +76,8 @@ systemctl enable manage_user_groups.service
 #   /usr/share/initramfs-tools/scripts/casper-bottom/
 
 # remove build stuff no longer of use
-apt-get --yes remove libboost1.74-dev gcc-11 g++-11 gfortran-11 build-essential
+apt-get --yes remove libboost1.74-dev gcc-11 g++-11 gfortran-11 build-essential \
+  libicu-dev libc6-dev
 
 # remove stuff to save disk space (#467)
 apt-get --yes remove libreoffice-common libreoffice-core 2048-qt noblenote trojita \

--- a/bin/setdown.sh
+++ b/bin/setdown.sh
@@ -81,7 +81,7 @@ apt-get --yes remove libboost1.74-dev gcc-11 g++-11 gfortran-11 build-essential 
 
 # remove stuff to save disk space (#467)
 apt-get --yes remove libreoffice-common libreoffice-core 2048-qt noblenote trojita \
-  transmission-common k3b vlc snapd fonts-noto-cjk
+  transmission-common k3b vlc snapd fonts-noto-cjk apt-xapian-index
 
 # remove any leftover orphans
 apt-get --yes autoremove


### PR DESCRIPTION
Related with the following Trac tickets:
- [#2429 (Base Lubuntu ISO image needs to be stored in somewhere) – OSGeoLive](https://trac.osgeo.org/osgeolive/ticket/2429)
- [#467 (remove bulky orphaned packages) – OSGeoLive](https://trac.osgeo.org/osgeolive/ticket/467)

Upgrading base Lubuntu ISO image to 22.04.2 caused over 4G error, so I am trying to remove the following packages and caches.
- apt packages
  - `libicu-dev`
  - `libc6-dev`
  - `apt-xapian-index`
- caches
  - `/var/lib/apt/lists/*`