### PR TITLE
Update Cesium to version 1.106

### DIFF
--- a/bin/install_cesium.sh
+++ b/bin/install_cesium.sh
@@ -27,7 +27,7 @@ BIN_DIR=`pwd`
 BUILD_DIR='/tmp/build_cesium'
 WEB_DIR=cesium
 UNZIP_DIR="$BUILD_DIR/$WEB_DIR"
-CESIUM_VERSION="1.104"
+CESIUM_VERSION="1.106"
 ####
 
 if [ -z "$USER_NAME" ] ; then


### PR DESCRIPTION
CesiumJS released 1.106 at 2023-06-01,
https://github.com/CesiumGS/cesium/releases/tag/1.106

and I encountered the following error again with the latest nightly build ([osgeolive-nightly-build76-amd64-f2c311c-master.iso](https://download.osgeo.org/livedvd/nightly/osgeolive-nightly-build76-amd64-f2c311c-master.iso)).
[#2398 (Cesium doesn't show a map with InvalidCredentials (401) error) – OSGeoLive](https://trac.osgeo.org/osgeolive/ticket/2398)
![build76-f2c311c-cesium-error](https://github.com/OSGeo/OSGeoLive/assets/629923/8ceb41a5-c81a-4a54-9aa7-f3ae25335a49)

---

So, I updated the Cesium version like the previous commit (https://github.com/OSGeo/OSGeoLive/commit/af015489f7abd8e0c98c8c35d4ec485568d8dfc4), and confirmed that the error was not happened.

One good point with this upgrade is "Google Photorealistic 3D Tiles" (since [1.105.1](https://github.com/CesiumGS/cesium/releases/tag/1.105.1)) examples are available from Sandcastle. 😄
![cesium-1_106-google-photorealistic3dtiles](https://github.com/OSGeo/OSGeoLive/assets/629923/92779484-e8bc-400c-b328-0c15629ec4ec)