### PR TITLE
Update actinia versions

### DIFF
--- a/bin/install_actinia.sh
+++ b/bin/install_actinia.sh
@@ -86,7 +86,7 @@ $ACTINIA_HOME/venv-actinia/bin/python3 -m pip install actinia-core
 # actinia plugins
 $ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-statistic-plugin/releases/download/0.2.2/actinia_statistic_plugin-0.2.2-py2.py3-none-any.whl
 $ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-satellite-plugin/releases/download/0.1.2/actinia_satellite_plugin-0.1.2-py2.py3-none-any.whl
-$ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-module-plugin/releases/download/2.6.0/actinia_module_plugin-2.6.0-py3-none-any.whl
+$ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-module-plugin/releases/download/2.6.1/actinia_module_plugin-2.6.1-py3-none-any.whl
 
 # left out in OSGeolive
 ## Add default password for redis

--- a/bin/install_actinia.sh
+++ b/bin/install_actinia.sh
@@ -67,7 +67,7 @@ mkdir -p "$ACTINIA_HOME"/workspace/download_cache
 mkdir -p "$ACTINIA_HOME"/userdata
 
 apt-get -q update
-apt-get --assume-yes install redis-server
+apt-get --assume-yes install build-essential python3-dev redis-server
 
 # install actinia in python virtualenv
 apt-get install -y python3-venv
@@ -86,7 +86,7 @@ $ACTINIA_HOME/venv-actinia/bin/python3 -m pip install actinia-core
 # actinia plugins
 $ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-statistic-plugin/releases/download/0.2.2/actinia_statistic_plugin-0.2.2-py2.py3-none-any.whl
 $ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-satellite-plugin/releases/download/0.1.2/actinia_satellite_plugin-0.1.2-py2.py3-none-any.whl
-$ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-module-plugin/releases/download/2.6.0/actinia_module_plugin.wsgi-2.6.0-py2.py3-none-any.whl
+$ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-module-plugin/releases/download/2.6.0/actinia_module_plugin-2.6.0-py3-none-any.whl
 
 # left out in OSGeolive
 ## Add default password for redis

--- a/bin/install_actinia.sh
+++ b/bin/install_actinia.sh
@@ -4,7 +4,7 @@
 # Purpose: This script will install actinia_core (REST API for GRASS GIS 8)
 #
 # References:
-#          - Code: https://github.com/actinia-org/actinia-gdi
+#          - Code: https://github.com/actinia-org/actinia-core
 #          - Publication: https://doi.org/10.5281/zenodo.2631917
 #          - Tutorial: https://actinia.mundialis.de/tutorial/
 #
@@ -14,7 +14,7 @@
 #
 #################################################################################
 # Copyright (c) 2018-2019 Sören Gebbert and mundialis GmbH & Co. KG, Bonn.
-# Copyright (c) 2020-2023 The Open Source Geospatial Foundation and others.
+# Copyright (c) 2020-2024 The Open Source Geospatial Foundation and others.
 #
 # Installer script author: Markus Neteler <neteler mundialis.de>
 #
@@ -83,13 +83,10 @@ $ACTINIA_HOME/venv-actinia/bin/python3 -m pip install boto3 colorlog flask_cors 
 # latest actinia-core installation
 $ACTINIA_HOME/venv-actinia/bin/python3 -m pip install actinia-core
 
-# actinia API
-$ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-api/releases/download/3.4.0/actinia_api-3.4.0-py3-none-any.whl
-
 # actinia plugins
-$ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-statistic-plugin/releases/download/0.2.1/actinia_statistic_plugin-0.2.1-py2.py3-none-any.whl
-$ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-satellite-plugin/releases/download/0.1.0/actinia_satellite_plugin-0.1.0-py2.py3-none-any.whl
-$ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-module-plugin/releases/download/2.5.0/actinia_module_plugin.wsgi-2.5.0-py2.py3-none-any.whl
+$ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-statistic-plugin/releases/download/0.2.2/actinia_statistic_plugin-0.2.2-py2.py3-none-any.whl
+$ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-satellite-plugin/releases/download/0.1.2/actinia_satellite_plugin-0.1.2-py2.py3-none-any.whl
+$ACTINIA_HOME/venv-actinia/bin/python3 -m pip install https://github.com/actinia-org/actinia-module-plugin/releases/download/2.6.0/actinia_module_plugin.wsgi-2.6.0-py2.py3-none-any.whl
 
 # left out in OSGeolive
 ## Add default password for redis


### PR DESCRIPTION
This PR
- updates versions of actinia plugins
- removes separate installation of actinia-api as it is automatically installed with `pip install actinia-core`. This way, no version mismatch can occur.

~~(Draft as not tested yet)~~