### PR TITLE
Bump MapServer Docs version

### DIFF
--- a/bin/install_mapserver.sh
+++ b/bin/install_mapserver.sh
@@ -56,7 +56,7 @@ apt-get install --yes cgi-mapserver mapserver-bin python3-mapscript php-mapscrip
 # Download MapServer data
 
 MS_DEMO_VERSION="1.2"
-MS_DOCS_VERSION="8-0"
+MS_DOCS_VERSION="8-2"
 
 wget -c --progress=dot:mega \
     "http://download.osgeo.org/livedvd/data/mapserver/mapserver-$MS_DOCS_VERSION-html-docs.zip"


### PR DESCRIPTION
I've created the 8.2 MapServer docs and uploaded a zip file in the same format as previously versions to: https://www.dropbox.com/scl/fi/ie8qu6o2klq2s7ao2qall/mapserver-8-2-html-docs.zip?rlkey=iuldwi916mhprtgeyu0lzcl97&st=4q2yv4ur&dl=0

Filename: `mapserver-8-2-html-docs.zip` (~18MB).

This needs to be uploaded to http://download.osgeo.org/livedvd/data/mapserver/ as was done with previous versions (e.g. http://download.osgeo.org/livedvd/data/mapserver/mapserver-8-0-html-docs.zip)

Should fix https://trac.osgeo.org/osgeolive/ticket/2410 once the zip is in place.




