### PR TITLE
MapServer fixes to allow Mapfiles in /home/user

### DIFF
--- a/app-conf/mapserver/mapserver.conf
+++ b/app-conf/mapserver/mapserver.conf
@@ -1,6 +1,7 @@
 CONFIG
   ENV
-    MS_MAP_PATTERN "^\/usr\/local\/((\.\/)?|([^\.][-_A-Za-z0-9\.]*\/{1}))*([-_A-Za-z0-9\.]+\.(map))$"
+    # allow Mapfiles from any location but they must end with .map
+    MS_MAP_PATTERN ".*/.*\.map$"
     MS_MAP_BAD_PATTERN "[/\\]{2}|[/\\]?\.{2,}[/\\]|,"
     OGCAPI_HTML_TEMPLATE_DIRECTORY "/usr/share/mapserver/ogcapi/templates/html-plain/"
   END

--- a/bin/install_mapserver.sh
+++ b/bin/install_mapserver.sh
@@ -59,7 +59,7 @@ MS_DEMO_VERSION="1.2"
 MS_DOCS_VERSION="8-2"
 
 wget -c --progress=dot:mega \
-    "http://download.osgeo.org/livedvd/data/mapserver/mapserver-$MS_DOCS_VERSION-html-docs.zip"
+    "https://download.osgeo.org/livedvd/data/mapserver/mapserver-$MS_DOCS_VERSION-html-docs.zip"
 wget -c --progress=dot:mega \
    "https://github.com/mapserver/mapserver-demo/archive/v$MS_DEMO_VERSION.zip"
 
@@ -146,6 +146,8 @@ EOF
 cp /usr/share/applications/mapserver.desktop "$USER_HOME/Desktop/"
 chown "$USER_NAME:$USER_NAME" "$USER_HOME/Desktop/mapserver.desktop"
 
+# allow Mapfiles to be read from /home/user
+chmod o+rx "$USER_HOME"
 
 # share data with the rest of the disc
 ln -s /usr/local/share/mapserver/demos/itasca/data \


### PR DESCRIPTION
This pull request includes the following changes:

- allows Mapfiles to be loaded from any location. As discussed in https://github.com/OSGeo/OSGeoLive-doc/pull/869 - the quickstart asks uses to save files in the `/home/user` directory. The current `MS_MAP_PATTERN` only allowed for Mapfiles in `/usr/local`.
- Grants execute permissions on the `/home/user` directory (execute in this case means the user can read the contents, not execute scripts). Without this MapServer can't read the file and returns `msLoadMap(): Unable to access file. (/home/user/mapserver_quickstart.map)`.
- Switches the docs download to HTTPS