### PR TITLE
Update Cesium from 1.121 to 1.123

### DIFF
--- a/bin/install_cesium.sh
+++ b/bin/install_cesium.sh
@@ -27,7 +27,7 @@ BIN_DIR=`pwd`
 BUILD_DIR='/tmp/build_cesium'
 WEB_DIR=cesium
 UNZIP_DIR="$BUILD_DIR/$WEB_DIR"
-CESIUM_VERSION="1.121"
+CESIUM_VERSION="1.123"
 ####
 
 if [ -z "$USER_NAME" ] ; then


### PR DESCRIPTION
I noticed that Cesium doesn't show a map with token error again in the nightly build95 iso.
I am not sure whether today's Cesium 1.123 release affected the issue.
* https://trac.osgeo.org/osgeolive/ticket/2398
* https://x.com/CesiumJS/status/1852475682640539703

Updating Cesium version from 1.121 to 1.123 resolved the issue on my local built iso, so reviewing this is helpful.