### PR TITLE
fixed acl error in install_mapbender.sh - two rows deleted not needed

### DIFF
--- a/bin/install_mapbender.sh
+++ b/bin/install_mapbender.sh
@@ -93,11 +93,9 @@ cp "$BUILD_DIR"/../app-conf/mapbender/doctrine.yaml  "$INSTALL_DIR/mapbender/con
 
 bin/console doctrine:database:create
 bin/console doctrine:schema:create
-bin/console init:acl
 bin/console assets:install public --symlink --relative
 bin/console fom:user:resetroot --username="root" --password="root" --email="root@example.com" --silent
 bin/console mapbender:database:init -v
-bin/console mapbender:application:import config/applications
 
 chown -R user:www-data "$INSTALL_DIR/mapbender"
 chmod -R ug+w "$INSTALL_DIR/mapbender/var/cache/"


### PR DESCRIPTION
deleted not needed installation steps