### PR TITLE
Remove MS_MAP_BAD_PATTERN from mapserver.conf

### DIFF
--- a/app-conf/mapserver/mapserver.conf
+++ b/app-conf/mapserver/mapserver.conf
@@ -2,7 +2,6 @@ CONFIG
   ENV
     # allow Mapfiles from any location but they must end with .map
     MS_MAP_PATTERN ".*/.*\.map$"
-    MS_MAP_BAD_PATTERN "[/\\]{2}|[/\\]?\.{2,}[/\\]|,"
     OGCAPI_HTML_TEMPLATE_DIRECTORY "/usr/share/mapserver/ogcapi/templates/html-plain/"
   END
 


### PR DESCRIPTION
Likely due to the switching to use [PCRE2 instead of POSIX]( https://github.com/MapServer/MapServer/pull/7073) the regex used in `mapserver.conf` for `MS_MAP_BAD_PATTERN` is throwing errors: `MS_MAP_BAD_PATTERN "[/\\]{2}|[/\\]?\.{2,}[/\\]|,"`:

![image](https://github.com/user-attachments/assets/c260305a-20fe-49fb-9012-8a7fa9533c4f)

Removing this from the config file means the valid default is used from https://github.com/MapServer/MapServer/blob/d54aae0311066e116974ef888b82959bcefb8c24/src/mapservutil.c#L174

`const char *ms_map_bad_pattern_default = "[/\\\\]{2}|[/\\\\]?\\.+[/\\\\]|,";`

With this update, the MapServer demo is working again for me using osgeolive-nightly-build130-amd64-663f4e3-master.iso

@kalxas - should fix https://trac.osgeo.org/osgeolive/ticket/2501



